### PR TITLE
feat: publish DSA Mastery with GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,74 @@
+name: Deploy course site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run content and site tests
+        run: npm test
+
+      - name: Lint source
+        run: npm run lint
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Apply vinext Pages compatibility fix
+        run: node scripts/patch-vinext-pages.mjs
+
+      - name: Build static course site
+        env:
+          GITHUB_PAGES: "true"
+          GITHUB_PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+          NEXT_PUBLIC_SITE_URL: ${{ steps.pages.outputs.base_url }}/
+        run: npm run build
+
+      - name: Prepare and verify Pages artifact
+        env:
+          GITHUB_PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+        run: node scripts/prepare-pages-artifact.mjs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist/pages
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ DSA Mastery 是两名学生共同维护、面向课程学习者的数据结构�
 
 当前是用于团队讨论的 **Demo / MVP**，重点是用第 0、1 章验证这套教程结构是否清楚、实验是否可复现、网站是否适合持续阅读，而不是一次性做完一本教材。
 
+在线课程网站：[https://azenann.github.io/DSA-Mastery/](https://azenann.github.io/DSA-Mastery/)
+
 ## 希望读者最终做到
 
 - 准确说明核心概念、ADT、表示方法与关键不变量，而不是只背结论。
@@ -74,6 +76,8 @@ duration: "45～60 分钟"
 
 保存文件后，开发模式会更新页面；正式合并前运行构建和测试即可验证站点。完整步骤、命名规则与检查清单见 [更新工作流](docs/UPDATE_WORKFLOW.md)。
 
+通过 Review 的改动合并到 `main` 后，GitHub Actions 会自动完成内容检查、网站测试、静态构建与 GitHub Pages 发布。维护者无需提交 `dist/` 等生成目录；发布状态可在仓库的 **Actions** 页面查看。
+
 ## 仓库导览
 
 ```text
@@ -92,12 +96,12 @@ dsa-mastery/
 ├─ docs/
 │  ├─ PROJECT_BLUEPRINT.md      # 项目定位、架构、路线图与风险
 │  └─ UPDATE_WORKFLOW.md        # 日常新增章节、Lab 与 Review 流程
-└─ .github/                     # Issue 与 Pull Request 模板
+└─ .github/                     # 协作模板与 GitHub Pages 自动发布
 ```
 
 建议从以下入口开始：
 
-- 想读教材：进入 `content/`，或运行网站后在线阅读。
+- 想读教材：访问[在线课程网站](https://azenann.github.io/DSA-Mastery/)，或进入 `content/` 阅读 Markdown。
 - 想做实验：进入 `labs/`，按 Lab 的目标、步骤和验收清单完成。
 - 想参与更新：先读 [CONTRIBUTING.md](CONTRIBUTING.md) 和 [更新工作流](docs/UPDATE_WORKFLOW.md)。
 - 想理解长期规划：阅读 [项目蓝图](docs/PROJECT_BLUEPRINT.md)。
@@ -141,11 +145,11 @@ fix/linear-list-complexity
 
 **MVP 现在做：** 两章 Markdown、基础网站、少量 Lab、稳定的新增内容规则、轻量 Review。
 
-**验证后再做：** 按课程主线补齐章节、综合练习与可运行 Lab，再逐步加入交互可视化、多语言实现、Benchmark、LaTeX/PDF、版本发布与更完整的 CI/CD。先证明内容能够形成真实的读者能力，再增加基础设施。
+**验证后再做：** 按课程主线补齐章节、综合练习与可运行 Lab，再逐步加入交互可视化、多语言实现、Benchmark、LaTeX/PDF、版本发布与更完整的质量门禁和预览流程。先证明内容能够形成真实的读者能力，再增加基础设施。
 
 ## 贡献与许可
 
-欢迎通过 Issue 提出勘误、实验建议和章节改进。提交内容前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。项目正式公开前，维护者仍需共同确定内容与代码 License；在 License 明确之前，不应假设仓库内容可以被任意复制或再分发。
+欢迎通过 Issue 提出勘误、实验建议和章节改进。提交内容前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。仓库目前公开可见，但尚未添加明确的内容与代码 License；公开可见不等于获得复制、修改或再分发授权。维护者应尽快共同确定许可方案，在此之前请先取得作者明确许可。
 
 引用教材、论文、网页、图片或开源代码时必须标明来源和许可，尽量用自己的结构与语言讲解，不复制受版权保护的正文或图表。详见 [更新工作流中的版权规则](docs/UPDATE_WORKFLOW.md#8-版权引用与-ai-复核)。
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,47 +1,40 @@
 import type { Metadata } from "next";
-import { headers } from "next/headers";
 import "katex/dist/katex.min.css";
 import "./globals.css";
 import { SiteHeader } from "@/components/site-header";
 import { getSearchItems } from "@/lib/content";
 
-export async function generateMetadata(): Promise<Metadata> {
-  const requestHeaders = await headers();
-  const host = requestHeaders.get("x-forwarded-host")
-    ?? requestHeaders.get("host")
-    ?? "localhost:3000";
-  const protocol = requestHeaders.get("x-forwarded-proto")
-    ?? (/^(localhost|127\.)/.test(host) ? "http" : "https");
-  const origin = `${protocol}://${host}`;
-  const description = "从概念、ADT 与复杂度推导，到动手实现、边界测试与典型问题训练，帮助课程学习者扎实掌握数据结构与算法。";
-  const imageUrl = new URL("/og.png", origin).toString();
+const siteUrlValue = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000/";
+const siteUrl = new URL(siteUrlValue.endsWith("/") ? siteUrlValue : `${siteUrlValue}/`);
+const description = "从概念、ADT 与复杂度推导，到动手实现、边界测试与典型问题训练，帮助课程学习者扎实掌握数据结构与算法。";
+const imageUrl = new URL("og.png", siteUrl).toString();
+const faviconUrl = new URL("favicon.svg", siteUrl).toString();
 
-  return {
-    metadataBase: new URL(origin),
-    title: {
-      default: "DSA Mastery · 数据结构与算法理论与实验教程",
-      template: "%s · DSA Mastery",
-    },
+export const metadata: Metadata = {
+  metadataBase: siteUrl,
+  title: {
+    default: "DSA Mastery · 数据结构与算法理论与实验教程",
+    template: "%s · DSA Mastery",
+  },
+  description,
+  icons: {
+    icon: faviconUrl,
+    shortcut: faviconUrl,
+  },
+  openGraph: {
+    type: "website",
+    url: siteUrl,
+    title: "DSA Mastery · 数据结构与算法理论与实验教程",
     description,
-    icons: {
-      icon: "/favicon.svg",
-      shortcut: "/favicon.svg",
-    },
-    openGraph: {
-      type: "website",
-      url: origin,
-      title: "DSA Mastery · 数据结构与算法理论与实验教程",
-      description,
-      images: [{ url: imageUrl, width: 1672, height: 941, alt: "DSA Mastery 项目分享封面" }],
-    },
-    twitter: {
-      card: "summary_large_image",
-      title: "DSA Mastery · 数据结构与算法理论与实验教程",
-      description,
-      images: [imageUrl],
-    },
-  };
-}
+    images: [{ url: imageUrl, width: 1672, height: 941, alt: "DSA Mastery 项目分享封面" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "DSA Mastery · 数据结构与算法理论与实验教程",
+    description,
+    images: [imageUrl],
+  },
+};
 
 const themeScript = `
   try {

--- a/docs/PROJECT_BLUEPRINT.md
+++ b/docs/PROJECT_BLUEPRINT.md
@@ -173,7 +173,7 @@ Issue/目标
 - 公式与代码：由网站渲染层统一处理，正文保留标准 Markdown/数学标记。
 - Lab：每个 Lab 一个独立目录，从 `README.md` 开始，按需要增加代码与测试。
 - 验证：`npm run validate:content`、`npm run build`、`npm test`，必要时运行 `npm run lint`。
-- 托管：在内容结构稳定后再确定持续部署方案。
+- 托管：公开仓库通过 GitHub Actions 自动构建并发布到 [GitHub Pages](https://azenann.github.io/DSA-Mastery/)；生成目录不进入 Git。
 
 ### 为什么暂不以 LaTeX 为主源码
 
@@ -219,7 +219,7 @@ Pull Request
   └─ install → metadata/link check → lint → test → website build
 
 main
-  └─ 同一组质量检查 → 部署网站
+  └─ 同一组质量检查 → GitHub Pages 公开课程网站
                          └─ 未来再追加 PDF/Release artifact
 ```
 
@@ -294,9 +294,9 @@ main
 - 从一个高价值交互（如排序单步执行）开始。
 - 每个交互都要有确定状态模型、重置能力和测试。
 
-### Phase 6：开源完善
+### Phase 6：公开协作完善
 
-- 明确 License、治理、版本节奏和外部贡献机制。
+- 仓库已经公开；下一步明确 License、治理、版本节奏和外部贡献机制。
 - 只有贡献规模需要时再引入更复杂的 Project Board 与自动发布。
 
 ## 13. 第一个月行动计划

--- a/docs/UPDATE_WORKFLOW.md
+++ b/docs/UPDATE_WORKFLOW.md
@@ -113,7 +113,7 @@ Reviewer 从“零上下文读者”的角度检查：
 
 ### Step 7：Human Final Review & Merge
 
-Reviewer 对照 DoD，确认自动检查通过、阻塞评论解决后批准并使用 squash merge。默认由 Reviewer 合并，确保作者不会绕过同伴审核。合并后删除分支，关闭 Issue，并检查 `main` 的网站构建。
+Reviewer 对照 DoD，确认自动检查通过、阻塞评论解决后批准并使用 squash merge。默认由 Reviewer 合并，确保作者不会绕过同伴审核。合并后删除分支，关闭 Issue，并检查 `main` 上的 **Deploy course site to GitHub Pages** 工作流；发布成功后抽查[在线课程网站](https://azenann.github.io/DSA-Mastery/)中的新页面。
 
 ### Step 8：Retrospective
 
@@ -166,6 +166,14 @@ PR 描述需要回答：
 - 关联哪个 Issue。
 
 不要在同一 PR 顺便重构无关网站代码。纯排版批量修改与知识内容修改尽量拆开，方便 Review 差异。
+
+### 网站发布与回滚
+
+- `main` 是公开课程网站的唯一正式发布源；分支和 PR 不直接覆盖线上内容。
+- 合并到 `main` 后，GitHub Actions 自动执行内容检查、普通网站测试、Pages 静态构建和发布，不提交 `dist/`、`.next/` 等生成目录。
+- 发布完成后，在 Actions 中确认工作流为绿色，再抽查首页、新页面、前后页链接、搜索和至少一个 Lab。
+- 发布失败时，在短分支中修复并重新走 PR；不要通过跳过检查或手工上传构建产物绕过流水线。
+- 已上线内容需要紧急撤回时，优先创建一个回退 PR 或使用 GitHub 的 Revert 生成新提交，不强推或改写 `main` 历史。
 
 ### Tag 与 Release
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,17 @@
 import type { NextConfig } from "next";
 
+const isGitHubPagesBuild = process.env.GITHUB_PAGES === "true";
+const repositoryName = process.env.GITHUB_REPOSITORY?.split("/").at(-1);
+const derivedGitHubPagesBasePath = repositoryName && !repositoryName.endsWith(".github.io")
+  ? `/${repositoryName}`
+  : "";
+const githubPagesBasePath = process.env.GITHUB_PAGES_BASE_PATH
+  ?? derivedGitHubPagesBasePath;
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: isGitHubPagesBuild ? "export" : undefined,
+  basePath: isGitHubPagesBuild ? githubPagesBasePath : undefined,
+  trailingSlash: isGitHubPagesBuild,
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "tailwindcss": "4.2.1",
         "typescript": "5.9.3",
         "typescript-eslint": "8.59.3",
-        "vinext": "1.0.0-beta.2",
+        "vinext": "1.0.0-beta.5",
         "vite": "8.0.13",
         "wrangler": "4.92.0"
       },
@@ -9232,9 +9232,9 @@
       }
     },
     "node_modules/vinext": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/vinext/-/vinext-1.0.0-beta.2.tgz",
-      "integrity": "sha512-ihBni6mUKEDm69moFYLkt7dHzo/dX4hEqNgzB2+GCGpGKK5XWE40qGD1rxm9SHvsDDwzl+XeQCUVHcFwz/zZEw==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/vinext/-/vinext-1.0.0-beta.5.tgz",
+      "integrity": "sha512-c0I1UB70/pGwD9y4/iXWrGfz/LnowSbkQpUw+lK9t08tes5WHX7Vl0sZAY4MIzGaVCyvrD4/xZo7HWpMje6SwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tailwindcss": "4.2.1",
     "typescript": "5.9.3",
     "typescript-eslint": "8.59.3",
-    "vinext": "1.0.0-beta.2",
+    "vinext": "1.0.0-beta.5",
     "vite": "8.0.13",
     "wrangler": "4.92.0"
   },

--- a/scripts/patch-vinext-pages.mjs
+++ b/scripts/patch-vinext-pages.mjs
@@ -1,0 +1,66 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const packagePath = path.join(projectRoot, "node_modules", "vinext", "package.json");
+const prerenderPath = path.join(
+  projectRoot,
+  "node_modules",
+  "vinext",
+  "dist",
+  "build",
+  "prerender.js",
+);
+
+const vinextPackage = JSON.parse(await readFile(packagePath, "utf8"));
+if (vinextPackage.version !== "1.0.0-beta.5") {
+  throw new Error(
+    `Unsupported vinext version ${vinextPackage.version}. Review the Pages compatibility patch before upgrading.`,
+  );
+}
+
+const patches = [
+  {
+    name: "basePath-aware HTML prerender request",
+    before: '\t\t\t\tconst htmlRequest = new Request(`http://localhost${urlPath}`, { headers: htmlHeaders });',
+    after: [
+      '\t\t\t\tconst routedPath = config.trailingSlash && urlPath !== "/" ? `${urlPath}/` : urlPath;',
+      "\t\t\t\tconst requestPath = config.basePath",
+      '\t\t\t\t\t? routedPath === "/" ? `${config.basePath}/` : `${config.basePath}${routedPath}`',
+      "\t\t\t\t\t: routedPath;",
+      '\t\t\t\tconst htmlRequest = new Request(`http://localhost${requestPath}`, { headers: htmlHeaders });',
+    ].join("\n"),
+  },
+  {
+    name: "basePath-aware RSC prerender request",
+    before: '\t\t\t\t\tconst rscRequest = new Request(`http://localhost${urlPath}`, { headers: rscHeaders });',
+    after: '\t\t\t\t\tconst rscRequest = new Request(`http://localhost${requestPath}`, { headers: rscHeaders });',
+  },
+  {
+    name: "basePath-aware not-found prerender request",
+    before: '\t\t\tconst notFoundRequest = new Request(`http://localhost${NOT_FOUND_SENTINEL_PATH}`);',
+    after: [
+      '\t\t\tconst notFoundRoute = config.trailingSlash ? `${NOT_FOUND_SENTINEL_PATH}/` : NOT_FOUND_SENTINEL_PATH;',
+      '\t\t\tconst notFoundPath = config.basePath ? `${config.basePath}${notFoundRoute}` : notFoundRoute;',
+      '\t\t\tconst notFoundRequest = new Request(`http://localhost${notFoundPath}`);',
+    ].join("\n"),
+  },
+];
+
+let source = await readFile(prerenderPath, "utf8");
+let applied = 0;
+
+for (const patch of patches) {
+  if (source.includes(patch.after)) continue;
+  if (!source.includes(patch.before)) {
+    throw new Error(`Could not apply ${patch.name}; vinext internals changed.`);
+  }
+  source = source.replace(patch.before, patch.after);
+  applied += 1;
+}
+
+if (applied > 0) await writeFile(prerenderPath, source, "utf8");
+console.log(applied > 0
+  ? `Applied ${applied} vinext GitHub Pages compatibility patches.`
+  : "vinext GitHub Pages compatibility patches are already applied.");

--- a/scripts/prepare-pages-artifact.mjs
+++ b/scripts/prepare-pages-artifact.mjs
@@ -1,0 +1,62 @@
+import { access, cp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const clientRoot = path.join(projectRoot, "dist", "client");
+const pagesRoot = path.join(projectRoot, "dist", "pages");
+const repositoryName = process.env.GITHUB_REPOSITORY?.split("/").at(-1) ?? "";
+const derivedBasePath = repositoryName && !repositoryName.endsWith(".github.io")
+  ? `/${repositoryName}`
+  : "";
+const basePath = process.env.GITHUB_PAGES_BASE_PATH ?? derivedBasePath;
+
+if (basePath && (!basePath.startsWith("/") || basePath.endsWith("/"))) {
+  throw new Error(`Invalid GitHub Pages base path: ${basePath}`);
+}
+
+const nestedDirectory = basePath.replace(/^\/+/, "");
+const resolvedPagesRoot = path.resolve(pagesRoot);
+const resolvedDistRoot = path.resolve(projectRoot, "dist");
+if (!resolvedPagesRoot.startsWith(`${resolvedDistRoot}${path.sep}`)) {
+  throw new Error("Refusing to prepare an artifact outside the project dist directory.");
+}
+
+await rm(resolvedPagesRoot, { recursive: true, force: true });
+await mkdir(resolvedPagesRoot, { recursive: true });
+
+for (const entry of await readdir(clientRoot, { withFileTypes: true })) {
+  if (entry.name === ".vite" || entry.name === nestedDirectory) continue;
+  await cp(
+    path.join(clientRoot, entry.name),
+    path.join(resolvedPagesRoot, entry.name),
+    { recursive: entry.isDirectory() },
+  );
+}
+
+if (nestedDirectory) {
+  const nestedRoot = path.join(clientRoot, nestedDirectory);
+  for (const entry of await readdir(nestedRoot, { withFileTypes: true })) {
+    await cp(
+      path.join(nestedRoot, entry.name),
+      path.join(resolvedPagesRoot, entry.name),
+      { recursive: entry.isDirectory() },
+    );
+  }
+}
+
+await writeFile(path.join(resolvedPagesRoot, ".nojekyll"), "", "utf8");
+
+const requiredPaths = [
+  "index.html",
+  "404.html",
+  path.join("learn", "chapter-00-introduction", "00-overview", "index.html"),
+  path.join("labs", "chapter-01", "lab-01-02-linked-list", "index.html"),
+  "_next",
+];
+
+for (const relativePath of requiredPaths) {
+  await access(path.join(resolvedPagesRoot, relativePath));
+}
+
+console.log(`GitHub Pages artifact ready at ${path.relative(projectRoot, resolvedPagesRoot)}.`);


### PR DESCRIPTION
## What changed

- add a GitHub Actions workflow that tests, builds, and deploys the course site to GitHub Pages
- make metadata and internal routes work under the `/DSA-Mastery/` project path
- add a narrowly scoped vinext static-export compatibility step and verify the final artifact structure
- document the public course URL, automatic publishing, rollback workflow, and current license status
- update vinext from beta.2 to beta.5

## Why

The repository is now public and the course should be readable online. Markdown remains the single content source: merging new lesson or Lab Markdown into `main` automatically rebuilds and republishes the website.

## Validation

- `npm ci`
- `npm test` — 3/3 tests passed; 7 lessons and 4 Labs validated
- `npm run lint`
- GitHub Pages mode static export — 14 routes prerendered
- mounted-path smoke test — homepage, labs index, representative lesson, representative Lab, and CSS asset all returned HTTP 200

## User impact

After this PR merges and Pages is enabled, the public site will be available at https://azenann.github.io/DSA-Mastery/.