### PR TITLE
fix: restore lesson and Lab navigation on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,9 @@
 name: Deploy course site to GitHub Pages
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -12,7 +15,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -49,6 +52,8 @@ jobs:
         env:
           GITHUB_PAGES: "true"
           GITHUB_PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+          NEXT_PUBLIC_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+          NEXT_PUBLIC_DEPLOY_TARGET: github-pages
           NEXT_PUBLIC_SITE_URL: ${{ steps.pages.outputs.base_url }}/
         run: npm run build
 
@@ -57,12 +62,21 @@ jobs:
           GITHUB_PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
         run: node scripts/prepare-pages-artifact.mjs
 
+      - name: Install Chromium for navigation smoke test
+        run: npx playwright install --with-deps chromium
+
+      - name: Click through lesson and Lab routes
+        env:
+          GITHUB_PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+        run: npm run test:pages
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: dist/pages
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
 
 # next.js
 /.next/

--- a/app/labs/page.tsx
+++ b/app/labs/page.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight, Clock3, FlaskConical, Target } from "lucide-react";
 import type { Metadata } from "next";
-import Link from "next/link";
+import { SiteLink as Link } from "@/components/site-link";
 import { getChapterGroups, getLabs } from "@/lib/content";
 
 export const metadata: Metadata = {

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
+import { SiteLink as Link } from "@/components/site-link";
 
 export default function NotFound() {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import {
   RefreshCw,
   Sparkles,
 } from "lucide-react";
-import Link from "next/link";
+import { SiteLink as Link } from "@/components/site-link";
 import { getChapterGroups, getLabs, getLessons } from "@/lib/content";
 
 const learningLoop = ["理解", "推导", "实现", "测试", "练习", "讲解", "复盘", "迁移"];

--- a/components/docs-sidebar.tsx
+++ b/components/docs-sidebar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { BookOpen, ChevronDown, FlaskConical } from "lucide-react";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { ChapterGroup } from "@/lib/content";
+import { SiteLink as Link } from "./site-link";
 
 interface DocsSidebarProps {
   lessonGroups: ChapterGroup[];

--- a/components/document-view.tsx
+++ b/components/document-view.tsx
@@ -8,9 +8,9 @@ import {
   PencilLine,
   Users,
 } from "lucide-react";
-import Link from "next/link";
 import type { TutorialDocument } from "@/lib/content";
 import { MarkdownRenderer } from "./markdown-renderer";
+import { SiteLink as Link } from "./site-link";
 
 interface DocumentViewProps {
   document: TutorialDocument;

--- a/components/markdown-renderer.tsx
+++ b/components/markdown-renderer.tsx
@@ -5,13 +5,13 @@ import javascript from "highlight.js/lib/languages/javascript";
 import plaintext from "highlight.js/lib/languages/plaintext";
 import python from "highlight.js/lib/languages/python";
 import typescript from "highlight.js/lib/languages/typescript";
-import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { CopyButton } from "./copy-button";
+import { SiteLink as Link } from "./site-link";
 
 hljs.registerLanguage("bash", bash);
 hljs.registerLanguage("cpp", cpp);

--- a/components/mobile-docs-nav.tsx
+++ b/components/mobile-docs-nav.tsx
@@ -1,6 +1,6 @@
 import { Menu } from "lucide-react";
-import Link from "next/link";
 import type { ChapterGroup } from "@/lib/content";
+import { SiteLink as Link } from "./site-link";
 
 export function MobileDocsNav({
   lessonGroups,

--- a/components/search-palette.tsx
+++ b/components/search-palette.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { BookOpen, FlaskConical, Search, X } from "lucide-react";
-import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { SearchItem } from "@/lib/content";
+import { SiteLink as Link } from "./site-link";
 
 interface SearchPaletteProps {
   items: SearchItem[];

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,5 +1,5 @@
 import { BookOpen, Code2, FlaskConical } from "lucide-react";
-import Link from "next/link";
+import { SiteLink as Link } from "@/components/site-link";
 import type { SearchItem } from "@/lib/content";
 import { SearchPalette } from "./search-palette";
 import { ThemeToggle } from "./theme-toggle";

--- a/components/site-link.tsx
+++ b/components/site-link.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import type { AnchorHTMLAttributes } from "react";
+
+type SiteLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> & {
+  href: string;
+};
+
+const isGitHubPagesBuild = process.env.NEXT_PUBLIC_DEPLOY_TARGET === "github-pages";
+const githubPagesBasePath = (process.env.NEXT_PUBLIC_BASE_PATH ?? "").replace(/\/$/, "");
+
+function splitHref(href: string): [pathname: string, suffix: string] {
+  const suffixIndexes = [href.indexOf("?"), href.indexOf("#")].filter((index) => index >= 0);
+  const suffixIndex = suffixIndexes.length ? Math.min(...suffixIndexes) : href.length;
+  return [href.slice(0, suffixIndex), href.slice(suffixIndex)];
+}
+
+export function resolveStaticSiteHref(href: string): string {
+  if (!isGitHubPagesBuild || !href.startsWith("/") || href.startsWith("//")) return href;
+
+  const [pathname, suffix] = splitHref(href);
+  const routePath = pathname !== "/" && !pathname.endsWith("/") && !/\.[^/]+$/.test(pathname)
+    ? `${pathname}/`
+    : pathname;
+
+  if (!githubPagesBasePath) return `${routePath}${suffix}`;
+  if (routePath === githubPagesBasePath || routePath.startsWith(`${githubPagesBasePath}/`)) {
+    return `${routePath}${suffix}`;
+  }
+
+  const prefixedPath = routePath === "/"
+    ? `${githubPagesBasePath}/`
+    : `${githubPagesBasePath}${routePath}`;
+  return `${prefixedPath}${suffix}`;
+}
+
+export function SiteLink({ children, href, ...props }: SiteLinkProps) {
+  // Pages cannot serve vinext's header-driven RSC requests, so these links must load HTML documents.
+  if (isGitHubPagesBuild) {
+    return (
+      <a
+        {...props}
+        data-navigation-mode="document"
+        href={resolveStaticSiteHref(href)}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return <Link href={href} {...props}>{children}</Link>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@cloudflare/vite-plugin": "1.37.1",
         "@eslint/js": "9.39.4",
         "@next/eslint-plugin-next": "16.2.6",
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "4.2.1",
         "@types/node": "22.19.19",
         "@types/react": "19.2.14",
@@ -1325,6 +1326,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -7494,6 +7511,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "cross-env WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
     "validate:content": "node scripts/validate-content.mjs",
     "test": "npm run validate:content && npm run build && node --test tests/*.test.mjs",
+    "test:pages": "playwright test tests/pages-navigation.spec.mjs --reporter=line",
     "lint": "eslint . --ignore-pattern dist --ignore-pattern .next"
   },
   "dependencies": {
@@ -31,6 +32,7 @@
     "@cloudflare/vite-plugin": "1.37.1",
     "@eslint/js": "9.39.4",
     "@next/eslint-plugin-next": "16.2.6",
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "22.19.19",
     "@types/react": "19.2.14",

--- a/scripts/prepare-pages-artifact.mjs
+++ b/scripts/prepare-pages-artifact.mjs
@@ -1,4 +1,4 @@
-import { access, cp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { access, cp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -59,4 +59,54 @@ for (const relativePath of requiredPaths) {
   await access(path.join(resolvedPagesRoot, relativePath));
 }
 
-console.log(`GitHub Pages artifact ready at ${path.relative(projectRoot, resolvedPagesRoot)}.`);
+async function collectHtmlFiles(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await collectHtmlFiles(absolutePath));
+    else if (entry.name.endsWith(".html")) files.push(absolutePath);
+  }
+  return files;
+}
+
+function artifactTargetForHref(href) {
+  if (!href.startsWith("/") || href.startsWith("//")) return null;
+  const url = new URL(href, "https://pages.example");
+  const expectedPrefix = basePath ? `${basePath}/` : "/";
+  if (!url.pathname.startsWith(expectedPrefix)) {
+    throw new Error(`Document navigation escaped the Pages base path: ${href}`);
+  }
+
+  const routePath = basePath ? url.pathname.slice(basePath.length) : url.pathname;
+  const relativePath = routePath.replace(/^\/+/, "");
+  if (!relativePath) return path.join(resolvedPagesRoot, "index.html");
+  if (!routePath.endsWith("/")) {
+    if (path.extname(routePath)) return path.join(resolvedPagesRoot, relativePath);
+    throw new Error(`Document route is missing its trailing slash: ${href}`);
+  }
+  return path.join(resolvedPagesRoot, relativePath, "index.html");
+}
+
+let documentNavigationLinks = 0;
+const checkedTargets = new Set();
+for (const htmlPath of await collectHtmlFiles(resolvedPagesRoot)) {
+  const html = await readFile(htmlPath, "utf8");
+  for (const [tag] of html.matchAll(/<a\b[^>]*>/g)) {
+    if (!/\bdata-navigation-mode="document"/.test(tag)) continue;
+    documentNavigationLinks += 1;
+    const href = /\bhref="([^"]+)"/.exec(tag)?.[1];
+    if (!href) throw new Error(`Document navigation link has no href in ${htmlPath}`);
+    const target = artifactTargetForHref(href);
+    if (target) checkedTargets.add(target);
+  }
+}
+
+if (documentNavigationLinks === 0) {
+  throw new Error("Pages artifact contains no document-navigation links.");
+}
+for (const target of checkedTargets) await access(target);
+
+console.log(
+  `GitHub Pages artifact ready at ${path.relative(projectRoot, resolvedPagesRoot)} `
+  + `(${documentNavigationLinks} document links, ${checkedTargets.size} static targets verified).`,
+);

--- a/tests/pages-navigation.spec.mjs
+++ b/tests/pages-navigation.spec.mjs
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+import { readFile, stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const artifactRoot = path.join(projectRoot, "dist", "pages");
+const pagesBasePath = process.env.GITHUB_PAGES_BASE_PATH || "/DSA-Mastery";
+const mimeTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".rsc", "application/octet-stream"],
+  [".svg", "image/svg+xml"],
+  [".woff2", "font/woff2"],
+]);
+
+let server;
+let baseUrl;
+
+function resolveArtifactPath(relativePath) {
+  const resolvedPath = path.resolve(artifactRoot, relativePath);
+  if (resolvedPath !== artifactRoot && !resolvedPath.startsWith(`${artifactRoot}${path.sep}`)) {
+    throw new Error(`Refusing to serve a path outside the Pages artifact: ${relativePath}`);
+  }
+  return resolvedPath;
+}
+
+async function serveArtifact(request, response) {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  if (url.pathname === pagesBasePath) {
+    response.writeHead(301, { location: `${pagesBasePath}/` });
+    response.end();
+    return;
+  }
+  if (!url.pathname.startsWith(`${pagesBasePath}/`)) {
+    response.writeHead(404).end("Not found");
+    return;
+  }
+
+  const relativePath = decodeURIComponent(url.pathname.slice(pagesBasePath.length + 1));
+  let targetPath = resolveArtifactPath(relativePath);
+  try {
+    if ((await stat(targetPath)).isDirectory()) targetPath = path.join(targetPath, "index.html");
+    const body = await readFile(targetPath);
+    response.writeHead(200, {
+      "cache-control": "no-store",
+      "content-type": mimeTypes.get(path.extname(targetPath)) ?? "application/octet-stream",
+    });
+    response.end(body);
+  } catch {
+    const body = await readFile(path.join(artifactRoot, "404.html"));
+    response.writeHead(404, { "content-type": "text/html; charset=utf-8" });
+    response.end(body);
+  }
+}
+
+test.beforeAll(async () => {
+  server = createServer((request, response) => {
+    serveArtifact(request, response).catch((error) => {
+      response.writeHead(500).end(String(error));
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Could not start Pages test server.");
+  baseUrl = `http://127.0.0.1:${address.port}${pagesBasePath}`;
+});
+
+test.afterAll(async () => {
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+});
+
+test("lesson and Lab links use static document navigation", async ({ page }) => {
+  const failures = [];
+  const documentRequests = [];
+  const rscRequests = [];
+
+  page.on("pageerror", (error) => failures.push(`pageerror: ${error.message}`));
+  page.on("request", (request) => {
+    const requestUrl = new URL(request.url());
+    if (request.resourceType() === "document") documentRequests.push(requestUrl.pathname);
+    if (requestUrl.searchParams.has("_rsc")) rscRequests.push(request.url());
+  });
+  page.on("requestfailed", (request) => {
+    const errorText = request.failure()?.errorText ?? "unknown failure";
+    if (!errorText.includes("ERR_ABORTED")) failures.push(`${request.url()}: ${errorText}`);
+  });
+  page.on("response", (response) => {
+    const request = response.request();
+    const requestUrl = new URL(response.url());
+    const checkedTypes = new Set(["document", "fetch", "script", "stylesheet"]);
+    if (requestUrl.origin === new URL(baseUrl).origin
+      && checkedTypes.has(request.resourceType())
+      && response.status() >= 400) {
+      failures.push(`${response.status()} ${response.url()}`);
+    }
+  });
+
+  await page.goto(`${baseUrl}/`);
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("学透、做实、用活");
+
+  const lessonUrl = `${baseUrl}/learn/chapter-00-introduction/00-overview/`;
+  await Promise.all([
+    page.waitForURL(lessonUrl),
+    page.getByRole("link", { name: /从第 0 章开始/ }).click(),
+  ]);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("第 0 章 绪论");
+
+  const labsUrl = `${baseUrl}/labs/`;
+  await Promise.all([
+    page.waitForURL(labsUrl),
+    page.getByRole("navigation", { name: "主导航" }).getByRole("link", { name: "Labs" }).click(),
+  ]);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("用实验把理解落到代码上");
+
+  const labUrl = `${baseUrl}/labs/chapter-01/lab-01-02-linked-list/`;
+  await Promise.all([
+    page.waitForURL(labUrl),
+    page.locator("a.labs-list-card").filter({ hasText: "Lab 01-02：实现并验证单链表" }).click(),
+  ]);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Lab 01-02：实现并验证单链表");
+
+  expect(documentRequests).toEqual(expect.arrayContaining([
+    `${pagesBasePath}/learn/chapter-00-introduction/00-overview/`,
+    `${pagesBasePath}/labs/`,
+    `${pagesBasePath}/labs/chapter-01/lab-01-02-linked-list/`,
+  ]));
+  expect(rscRequests, "GitHub Pages navigation must not issue RSC requests").toEqual([]);
+  expect(failures).toEqual([]);
+});

--- a/tests/pages-navigation.test.mjs
+++ b/tests/pages-navigation.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function collectTsxFiles(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await collectTsxFiles(absolutePath));
+    else if (entry.name.endsWith(".tsx")) files.push(absolutePath);
+  }
+  return files;
+}
+
+test("all internal Link components use the Pages-aware wrapper", async () => {
+  const files = [
+    ...await collectTsxFiles(path.join(projectRoot, "app")),
+    ...await collectTsxFiles(path.join(projectRoot, "components")),
+  ];
+  const directNextLinkImports = [];
+  const unwrappedLinkComponents = [];
+
+  for (const file of files) {
+    const source = await readFile(file, "utf8");
+    const relativePath = path.relative(projectRoot, file).replaceAll("\\", "/");
+    if (/from ["']next\/link["']/.test(source)) directNextLinkImports.push(relativePath);
+    if (relativePath !== "components/site-link.tsx" && /<Link\b/.test(source)
+      && !/SiteLink as Link/.test(source)) {
+      unwrappedLinkComponents.push(relativePath);
+    }
+  }
+
+  assert.deepEqual(directNextLinkImports, ["components/site-link.tsx"]);
+  assert.deepEqual(unwrappedLinkComponents, []);
+});
+
+test("GitHub Pages builds opt into static document navigation", async () => {
+  const component = await readFile(path.join(projectRoot, "components", "site-link.tsx"), "utf8");
+  const workflow = await readFile(path.join(projectRoot, ".github", "workflows", "pages.yml"), "utf8");
+
+  assert.match(component, /NEXT_PUBLIC_DEPLOY_TARGET === "github-pages"/);
+  assert.match(component, /NEXT_PUBLIC_BASE_PATH/);
+  assert.match(component, /data-navigation-mode="document"/);
+  assert.match(workflow, /NEXT_PUBLIC_DEPLOY_TARGET:\s*github-pages/);
+  assert.match(workflow, /NEXT_PUBLIC_BASE_PATH:\s*\$\{\{ steps\.pages\.outputs\.base_path \}\}/);
+});


### PR DESCRIPTION
## 这次更新解决什么

修复 GitHub Pages 线上站点中“目标页面直接打开正常，但从首页、目录、搜索或 Lab 卡片点击后无法跳转”的问题。

### 现象与根因

- `/DSA-Mastery/learn/...` 和 `/DSA-Mastery/labs/...` 的静态 HTML 均存在，直接访问返回 200。
- 页面上的 `href` 已正确带有 `/DSA-Mastery` basePath 和末尾斜杠。
- 点击由 `next/link` 接管后，vinext App Router 会请求 `目标路径/?_rsc=...`。
- GitHub Pages 对该请求返回 `text/html`；构建生成的同名 `.rsc` 文件则以 `application/octet-stream` 提供，无法满足 vinext 的 RSC 客户端导航协议。因此直接 URL 测试通过，真实点击仍会失败。

## 改动内容

- 新增统一的 `SiteLink`：GitHub Pages 构建中渲染为标准 `<a>`，补齐 Pages basePath 与 trailing slash，让浏览器发起可靠的 document 导航；本地开发、Cloudflare/Sites 等非 Pages 构建仍使用 `next/link`。
- 将首页、Labs 列表、头部、桌面/移动目录、搜索结果、Markdown 内链、面包屑、前后页与 404 的内部 Link 全部收口到 `SiteLink`。
- Pages 构建新增 `NEXT_PUBLIC_DEPLOY_TARGET` 与 `NEXT_PUBLIC_BASE_PATH`，避免把静态托管兼容逻辑扩散到其他环境。
- 强化 Pages artifact 校验：检查 document-navigation 链接没有逃逸 basePath、extensionless 路由带末尾斜杠，并确认每个静态目标真实存在。
- 新增 Chromium 点击回归：首页 → 第 0 章 → Labs → 单链表 Lab；同时断言没有 `?_rsc=` 请求、pageerror、失败请求或关键资源 4xx/5xx。
- Pages workflow 在 PR 中运行完整静态构建与点击测试，但 PR 不部署；合并到 `main` 后才部署。并发组按 ref 隔离，PR 检查不会取消主分支部署。

## 为什么采用整页导航

GitHub Pages 是纯静态服务器，无法根据 RSC 请求头返回 vinext 需要的响应。对教程站而言，Pages 上使用标准 document 导航是明确、可靠且易验证的取舍；课程内容、URL、SEO 与刷新直达均不受影响。若未来 vinext 原生支持 Pages 的静态 RSC 导航，可删除 Pages 专用分支，并继续用本 PR 的浏览器测试验证迁移。

## 验证记录

- [x] `npm run validate:content`：7 篇教材、4 个 Lab 通过
- [x] `npm run build`
- [x] `npm test`：5/5 通过
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] Pages 模式构建：14 条路由全部 prerender，0 skipped
- [x] artifact 校验：366 个 document 链接、13 个静态目标全部通过
- [x] `npm run test:pages`：1/1 Chromium 流程通过
- [x] 点击期间 `?_rsc=` 请求为 0，页面/网络错误为 0

## 内容完成标准

本 PR 不修改教材或 Lab 正文：

- [x] 学习目标、定义、复杂度、引用与术语未改动
- [x] Markdown 自动发现和内容注册规则未改动
- [x] Blocking review comments：当前无

## AI 使用与人工复核

使用 Codex 辅助定位静态托管与 RSC 导航差异、实现兼容层并编写测试。已通过实际 HTTP 响应比对、最终 artifact 扫描、TypeScript/ESLint/现有测试及 Chromium 点击流程交叉核验；没有依赖仅由 AI 推断的通过结论。

## Reviewer 重点关注

1. `components/site-link.tsx` 的 basePath/trailing-slash 规则是否符合未来自定义域名或仓库改名计划。
2. GitHub Pages 使用整页刷新、其他部署继续使用 `next/link` 的边界是否符合预期。
3. PR workflow 中 Chromium 安装时间与 15 分钟 job timeout 是否可接受。
4. 新增站内导航时应继续使用 `SiteLink`；源代码测试会阻止直接引入新的 `next/link`。