### PR TITLE
feat: add A* 寻路可视化文章pathfinding visualization

### DIFF
--- a/content/chapter-05-graph/04-astar-visualization.md
+++ b/content/chapter-05-graph/04-astar-visualization.md
@@ -1,0 +1,57 @@
+---
+title: "5.4 A* 寻路可视化"
+description: "通过交互式网格理解 A* 如何结合实际代价与启发式估计寻找最短路径。"
+order: 4
+chapter: 5
+chapterTitle: "图"
+updated: "2026-08-12"
+contributors: ["Codex"]
+status: "draft"
+---
+
+<script setup>
+import { withBase } from "vitepress";
+
+const demoUrl = withBase("/demos/astar-pathfinding.html");
+</script>
+
+# 5.4 A* 寻路可视化
+
+A* 是一种启发式寻路算法。它既记录从起点到当前格子已经付出的代价，也估计当前格子到终点还需要多远，并优先探索总评分最小的格子。
+
+$$
+f(n) = g(n) + h(n)
+$$
+
+- $g(n)$：从起点走到当前格子的实际代价；
+- $h(n)$：从当前格子到终点的估计代价；
+- $f(n)$：两者之和，用于决定下一步优先探索哪个格子。
+
+## 交互式演示
+
+点击“播放”观察完整过程，也可以逐步前进、拖动时间线、画墙或移动起点和终点。黄色表示开放集，紫色表示已经检查的格子，绿色表示最终路径。
+
+<iframe
+  :src="demoUrl"
+  title="A* 寻路交互式可视化"
+  class="astar-demo-frame"
+  loading="lazy"
+></iframe>
+
+<style scoped>
+.astar-demo-frame {
+  display: block;
+  width: 100%;
+  height: 980px;
+  margin: 20px 0;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: #21252b;
+}
+
+@media (max-width: 720px) {
+  .astar-demo-frame {
+    height: 1500px;
+  }
+}
+</style>

--- a/public/demos/astar-pathfinding.html
+++ b/public/demos/astar-pathfinding.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>A* 寻路可视化实验室</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg:#171a1f; --panel:#282c34; --panel2:#21252b; --line:#3e4451;
+      --text:#d7dae0; --muted:#8b929f; --cyan:#56b6c2; --yellow:#e5c07b;
+      --green:#98c379; --red:#e06c75; --purple:#c678dd; --blue:#61afef;
+      --cell:#303641; --wall:#111419;
+    }
+    *{box-sizing:border-box}
+    body{margin:0;min-height:100vh;background:radial-gradient(circle at 15% 0,#283445 0,transparent 35%),linear-gradient(145deg,#171a1f,#20252d);color:var(--text);font:15px/1.55 Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif}
+    button,select,input{font:inherit}
+    .app{width:min(1180px,calc(100% - 28px));margin:22px auto 38px}
+    .hero,.card{border:1px solid var(--line);background:color-mix(in srgb,var(--panel) 95%,transparent);box-shadow:0 18px 50px #090b1066}
+    .hero{position:relative;overflow:hidden;border-radius:22px;padding:25px 27px}
+    .hero::after{content:"A*";position:absolute;right:26px;top:-18px;font:900 116px/1 ui-monospace;color:#61afef0c;pointer-events:none}
+    .eyebrow{color:var(--cyan);font-weight:800;letter-spacing:.12em;text-transform:uppercase;font-size:.78rem}
+    h1{margin:2px 0 5px;color:#f5f7fa;font-size:clamp(1.8rem,4vw,2.75rem);line-height:1.15}
+    .hero p{max-width:720px;margin:0;color:var(--muted)}
+    .layout{display:grid;grid-template-columns:minmax(0,1.55fr) minmax(300px,.85fr);gap:16px;margin-top:16px}
+    .card{border-radius:18px;padding:17px}
+    .toolbar,.controls,.legend,.stats,.modebar{display:flex;flex-wrap:wrap;gap:9px;align-items:center}
+    .toolbar{justify-content:space-between;margin-bottom:13px}
+    .toolbar strong{color:#f4f6f9;font-size:1.05rem}
+    .modebar{padding:5px;background:var(--panel2);border:1px solid var(--line);border-radius:12px}
+    button,select{min-height:42px;border:1px solid var(--line);border-radius:10px;padding:8px 13px;background:#2c313c;color:#edf1f7;cursor:pointer;touch-action:manipulation}
+    button:hover,select:hover{border-color:var(--cyan)}
+    button:focus-visible,select:focus-visible,input:focus-visible,.cell:focus-visible{outline:3px solid var(--cyan);outline-offset:2px}
+    button.primary{background:linear-gradient(135deg,var(--blue),var(--cyan));color:#14202b;border:0;font-weight:850}
+    button.mode{min-height:34px;padding:5px 10px;border-color:transparent;background:transparent;color:var(--muted)}
+    button.mode.active{background:#3a4351;color:#fff;box-shadow:inset 0 0 0 1px #ffffff12}
+    .grid-shell{background:#1d2128;border:1px solid var(--line);border-radius:16px;padding:clamp(8px,2vw,14px);user-select:none;touch-action:none}
+    .grid{display:grid;grid-template-columns:repeat(12,1fr);gap:clamp(2px,.55vw,5px);aspect-ratio:12/8;max-height:560px;margin:auto}
+    .cell{position:relative;min-width:0;border:1px solid #424a58;border-radius:clamp(4px,.7vw,8px);background:var(--cell);color:#fff;padding:0;min-height:0;overflow:hidden;transition:transform .14s ease,background .18s ease,border-color .18s ease;cursor:pointer}
+    .cell:hover{transform:translateY(-1px);border-color:#8390a3}
+    .cell.wall{background:repeating-linear-gradient(135deg,#101319 0 7px,#181c23 7px 14px);border-color:#0d1015}
+    .cell.open{background:#6d5c37;border-color:var(--yellow)}
+    .cell.closed{background:#51355a;border-color:var(--purple)}
+    .cell.current{background:#27616b;border-color:#8fe5ee;box-shadow:0 0 0 2px #56b6c250,0 0 18px #56b6c266;z-index:2}
+    .cell.path{background:#426233;border-color:var(--green);box-shadow:inset 0 0 0 1px #b9ed9d55}
+    .cell.start{background:#296d4d;border-color:#86dfa9}
+    .cell.goal{background:#803e48;border-color:#ff8793}
+    .marker{position:absolute;inset:0;display:grid;place-items:center;font-weight:950;font-size:clamp(.56rem,1.6vw,1rem);text-shadow:0 1px 3px #000}
+    .cost{position:absolute;right:3px;bottom:1px;font:700 clamp(.42rem,1vw,.68rem)/1 ui-monospace;color:#fff;opacity:.82}
+    .arrow{position:absolute;left:3px;top:0;font-size:clamp(.5rem,1.2vw,.8rem);color:#fff;opacity:.75}
+    .legend{margin:12px 2px 3px;color:var(--muted);font-size:.85rem}
+    .key{display:inline-flex;align-items:center;gap:5px}.swatch{width:11px;height:11px;border-radius:3px;background:var(--c)}
+    .controls{border-top:1px solid var(--line);margin-top:13px;padding-top:13px}
+    input[type=range]{flex:1 1 180px;min-height:42px;accent-color:var(--purple);cursor:pointer}
+    .side{display:flex;flex-direction:column;gap:16px}.side .card{box-shadow:0 12px 36px #090b1045}
+    .meta{display:flex;justify-content:space-between;color:var(--muted);font-size:.88rem;margin-bottom:8px}
+    .badge{border:1px solid var(--line);border-radius:999px;padding:2px 9px;color:var(--yellow);background:#e5c07b12}
+    .narration{min-height:94px;border-left:4px solid var(--cyan);border-radius:9px;background:#20242b;padding:12px 13px;color:#eef1f5}
+    .formula{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:10px}
+    .formula div{text-align:center;background:#20242b;border:1px solid var(--line);border-radius:10px;padding:8px 4px}
+    .formula b{display:block;font:850 1.25rem ui-monospace;color:#fff}.formula span{color:var(--muted);font-size:.75rem}
+    .stats{margin-top:10px}.stat{flex:1;min-width:78px;background:#20242b;border-radius:10px;padding:7px 9px}.stat small{display:block;color:var(--muted)}.stat strong{color:#fff}
+    pre{margin:0;padding:9px 0;overflow:auto;border-radius:12px;background:#1e2229;border:1px solid #343a45}
+    code{font:13px/1.72 "Cascadia Code",Consolas,ui-monospace,monospace}
+    .code-line{display:block;padding:1px 12px;border-left:3px solid transparent;white-space:pre;color:#abb2bf}
+    .code-line.active{color:#fff;background:#3b3444;border-left-color:var(--purple)}
+    .tip{margin:10px 2px 0;color:var(--muted);font-size:.84rem}
+    .sr{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    @media(max-width:820px){.app{width:min(100% - 16px,680px);margin:8px auto 24px}.layout{grid-template-columns:1fr}.hero,.card{border-radius:14px}.hero{padding:20px}.side{display:grid;grid-template-columns:1fr}.cell{border-radius:4px}.cost{display:none}.controls button{flex:1 1 70px}.controls input{order:2;flex-basis:100%}}
+    @media(max-width:430px){.toolbar{align-items:flex-start}.modebar{width:100%;display:grid;grid-template-columns:repeat(3,1fr)}.hero::after{display:none}.grid-shell{padding:6px}.grid{gap:2px}.side .card{padding:14px}.legend{gap:8px}}
+    @media(prefers-reduced-motion:reduce){*,*::before,*::after{scroll-behavior:auto!important;transition-duration:.01ms!important;animation-duration:.01ms!important}}
+  </style>
+</head>
+<body>
+<main class="app">
+  <header class="hero">
+    <div class="eyebrow">Interactive Algorithm Lab</div>
+    <h1>A* 寻路可视化</h1>
+    <p>A* 像一位既看地图、又记路程的向导：它用已经走过的代价 g，加上到终点的估计 h，优先探索总分 f 最小的格子。</p>
+  </header>
+  <section class="layout">
+    <div class="card">
+      <div class="toolbar">
+        <strong>12 × 8 网格地图</strong>
+        <div class="modebar" aria-label="地图编辑工具">
+          <button class="mode active" data-mode="wall">画墙</button>
+          <button class="mode" data-mode="start">移动起点</button>
+          <button class="mode" data-mode="goal">移动终点</button>
+        </div>
+      </div>
+      <div class="grid-shell"><div id="grid" class="grid" role="grid" aria-label="A* 寻路网格"></div></div>
+      <div class="legend" aria-label="图例">
+        <span class="key"><i class="swatch" style="--c:var(--yellow)"></i>开放集（待考察）</span>
+        <span class="key"><i class="swatch" style="--c:var(--cyan)"></i>当前格</span>
+        <span class="key"><i class="swatch" style="--c:var(--purple)"></i>关闭集（已检查）</span>
+        <span class="key"><i class="swatch" style="--c:var(--green)"></i>最终路径</span>
+      </div>
+      <div class="controls" aria-label="播放控制">
+        <button data-action="reset">↺ 重置</button>
+        <button data-action="prev">← 上一步</button>
+        <button class="primary" data-action="play">▶ 播放</button>
+        <button data-action="next">下一步 →</button>
+        <input data-role="timeline" type="range" min="0" value="0" aria-label="时间线进度">
+        <select data-role="speed" aria-label="播放速度">
+          <option value="900">0.5× 慢速</option><option value="480" selected>1× 正常</option><option value="220">2× 快速</option><option value="80">4× 极速</option>
+        </select>
+      </div>
+      <p class="tip">提示：选择“画墙”后点击或拖过格子；也可以选择工具后移动起点和终点。编辑地图会自动重新计算。</p>
+    </div>
+    <aside class="side">
+      <section class="card">
+        <div class="meta"><span id="counter">步骤 0/0</span><span id="status" class="badge">准备</span></div>
+        <div id="narration" class="narration" aria-live="polite">准备好了。点击“播放”或“下一步”，观察 A* 如何权衡实际路程与剩余距离。</div>
+        <div class="formula" aria-label="当前节点代价">
+          <div><b id="gValue">—</b><span>g 已走代价</span></div><div><b id="hValue">—</b><span>h 估计剩余</span></div><div><b id="fValue">—</b><span>f 总评分</span></div>
+        </div>
+        <div class="stats"><div class="stat"><small>已检查</small><strong id="visited">0</strong></div><div class="stat"><small>开放集</small><strong id="openCount">0</strong></div><div class="stat"><small>路径长度</small><strong id="pathLength">—</strong></div></div>
+      </section>
+      <section class="card">
+        <div class="meta"><span>同步伪代码</span><span>曼哈顿距离</span></div>
+        <pre aria-label="A* 伪代码"><code><span class="code-line" data-line="1">open ← {起点}; g[起点] ← 0</span><span class="code-line" data-line="2">当 open 不为空：</span><span class="code-line" data-line="3">  current ← f 最小的格子</span><span class="code-line" data-line="4">  若 current 是终点，重建路径</span><span class="code-line" data-line="5">  将 current 移入 closed</span><span class="code-line" data-line="6">  对每个可通行的邻居：</span><span class="code-line" data-line="7">    计算 tentativeG = g[current] + 1</span><span class="code-line" data-line="8">    若路线更短，更新来源和 g、f</span><span class="code-line" data-line="9">若 open 为空，则没有可达路径</span></code></pre>
+      </section>
+    </aside>
+  </section>
+  <div id="live" class="sr" aria-live="assertive"></div>
+</main>
+<script>
+(() => {
+  "use strict";
+  const W=12,H=8,N=W*H;
+  const DEFAULT={start:12,goal:83,walls:[15,16,17,29,41,53,65,77,26,38,50,62,74,34,35,36,37,58,70,82,22,23,47,59,71,89,90,91]};
+  let map={start:DEFAULT.start,goal:DEFAULT.goal,walls:new Set(DEFAULT.walls)};
+  let events=[],frames=[],index=0,timer=null,mode="wall",painting=false,paintToWall=true;
+  const $=s=>document.querySelector(s);
+  const ui={grid:$("#grid"),play:$("[data-action=play]"),timeline:$("[data-role=timeline]"),speed:$("[data-role=speed]"),counter:$("#counter"),status:$("#status"),narration:$("#narration"),g:$("#gValue"),h:$("#hValue"),f:$("#fValue"),visited:$("#visited"),open:$("#openCount"),path:$("#pathLength"),live:$("#live")};
+
+  const rc=id=>[Math.floor(id/W),id%W];
+  const name=id=>{const [r,c]=rc(id);return `第 ${r+1} 行、第 ${c+1} 列`;};
+  const heuristic=(a,b)=>{const [ar,ac]=rc(a),[br,bc]=rc(b);return Math.abs(ar-br)+Math.abs(ac-bc);};
+  const neighbors=id=>{const [r,c]=rc(id);return [[r-1,c],[r,c+1],[r+1,c],[r,c-1]].filter(([y,x])=>y>=0&&y<H&&x>=0&&x<W).map(([y,x])=>y*W+x);};
+
+  function buildTrace(config){
+    const trace=[],open=new Set([config.start]),closed=new Set(),g=Array(N).fill(Infinity),came=Array(N).fill(null);
+    g[config.start]=0;
+    trace.push({type:"initialize",id:config.start,g:0,h:heuristic(config.start,config.goal),line:1,message:"把起点放入开放集。开放集保存接下来可能探索的格子。"});
+    while(open.size){
+      const current=[...open].sort((a,b)=>(g[a]+heuristic(a,config.goal))-(g[b]+heuristic(b,config.goal))||heuristic(a,config.goal)-heuristic(b,config.goal)||a-b)[0];
+      trace.push({type:"select",id:current,g:g[current],h:heuristic(current,config.goal),line:3,message:`从开放集中选择 f 最小的 ${name(current)}：g=${g[current]}，h=${heuristic(current,config.goal)}，所以 f=${g[current]+heuristic(current,config.goal)}。`});
+      if(current===config.goal){
+        const path=[];let node=current;while(node!==null){path.push(node);node=came[node];}path.reverse();
+        trace.push({type:"complete",id:current,path,line:4,message:`到达终点！沿着来源指针向后回溯，得到一条长度为 ${path.length-1} 的最短路径。`});
+        return trace;
+      }
+      open.delete(current);closed.add(current);
+      trace.push({type:"close",id:current,line:5,message:`${name(current)} 已经检查完毕，移入关闭集。它的当前最短代价已经确定。`});
+      for(const next of neighbors(current)){
+        if(config.walls.has(next)||closed.has(next)) continue;
+        const tentative=g[current]+1,wasOpen=open.has(next);
+        if(!wasOpen||tentative<g[next]){
+          came[next]=current;g[next]=tentative;open.add(next);
+          const h=heuristic(next,config.goal);
+          trace.push({type:"relax",id:next,from:current,g:tentative,h,line:8,message:`${name(next)} 可通行。经当前格到这里的 g=${tentative}，加上 h=${h}，得到 f=${tentative+h}；${wasOpen?"这条路线更短，更新记录":"将它加入开放集"}。`});
+        }else{
+          trace.push({type:"skip",id:next,from:current,g:g[next],h:heuristic(next,config.goal),line:7,message:`${name(next)} 已有同样短或更短的路线，无需更新。`});
+        }
+      }
+    }
+    trace.push({type:"fail",line:9,message:"开放集已经为空，仍未到达终点：当前地图不存在可通行路径。"});
+    return trace;
+  }
+
+  function initialState(){return{open:[],closed:[],current:null,came:{},costs:{},path:[],line:null,status:"ready",message:"准备好了。点击“播放”或“下一步”，观察 A* 如何权衡实际路程与剩余距离。",activeCost:null};}
+  function reduce(state,event){
+    const next={...state,open:[...state.open],closed:[...state.closed],came:{...state.came},costs:{...state.costs},path:[...state.path],line:event.line??state.line,message:event.message??state.message,current:event.id??state.current,activeCost:event.g==null?state.activeCost:{g:event.g,h:event.h,f:event.g+event.h}};
+    if(event.type==="initialize"){next.open=[event.id];next.costs[event.id]={g:event.g,h:event.h};next.status="running";}
+    if(event.type==="select"){next.current=event.id;next.status="running";}
+    if(event.type==="close"){next.open=next.open.filter(x=>x!==event.id);if(!next.closed.includes(event.id))next.closed.push(event.id);}
+    if(event.type==="relax"){if(!next.open.includes(event.id))next.open.push(event.id);next.came[event.id]=event.from;next.costs[event.id]={g:event.g,h:event.h};next.current=event.id;}
+    if(event.type==="skip")next.current=event.id;
+    if(event.type==="complete"){next.path=[...event.path];next.status="complete";next.current=event.id;}
+    if(event.type==="fail"){next.status="failed";next.current=null;next.activeCost=null;}
+    return next;
+  }
+
+  function rebuild(announce=false){
+    pause(false);events=buildTrace(map);frames=[initialState()];for(const event of events)frames.push(reduce(frames.at(-1),event));index=0;ui.timeline.max=frames.length-1;if(announce)ui.live.textContent="地图已更新，A* 演示已重新计算。";render();
+  }
+  function arrowFor(id,from){if(from==null)return"";const d=id-from;return d===1?"←":d===-1?"→":d===W?"↑":d===-W?"↓":"";}
+  function render(){
+    const s=frames[index],open=new Set(s.open),closed=new Set(s.closed),path=new Set(s.path);
+    const cells=[];
+    for(let id=0;id<N;id++){
+      const b=document.createElement("button");b.className="cell";b.dataset.id=id;b.setAttribute("role","gridcell");
+      if(map.walls.has(id))b.classList.add("wall");if(open.has(id))b.classList.add("open");if(closed.has(id))b.classList.add("closed");if(path.has(id))b.classList.add("path");if(s.current===id)b.classList.add("current");if(id===map.start)b.classList.add("start");if(id===map.goal)b.classList.add("goal");
+      const labels=[];if(id===map.start)labels.push("起点 S");if(id===map.goal)labels.push("终点 G");if(map.walls.has(id))labels.push("墙");if(path.has(id))labels.push("路径");if(open.has(id))labels.push("开放集");if(closed.has(id))labels.push("关闭集");if(s.current===id)labels.push("当前格");
+      b.setAttribute("aria-label",`${name(id)}，${labels.join("，")||"空地"}`);
+      if(id===map.start||id===map.goal){const m=document.createElement("span");m.className="marker";m.textContent=id===map.start?"S":"G";b.append(m);}
+      if(s.costs[id]){const c=document.createElement("span");c.className="cost";c.textContent=`f${s.costs[id].g+s.costs[id].h}`;b.append(c);}
+      if(s.came[id]!=null&&id!==map.start){const a=document.createElement("span");a.className="arrow";a.textContent=arrowFor(id,s.came[id]);b.append(a);}
+      cells.push(b);
+    }
+    ui.grid.replaceChildren(...cells);ui.timeline.value=index;ui.counter.textContent=`步骤 ${index}/${frames.length-1}`;
+    ui.status.textContent=s.status==="complete"?"已找到路径":s.status==="failed"?"无可达路径":index?"搜索中":"准备";ui.status.style.color=s.status==="complete"?"var(--green)":s.status==="failed"?"var(--red)":"var(--yellow)";
+    ui.narration.textContent=s.message;ui.g.textContent=s.activeCost?.g??"—";ui.h.textContent=s.activeCost?.h??"—";ui.f.textContent=s.activeCost?.f??"—";ui.visited.textContent=s.closed.length;ui.open.textContent=s.open.length;ui.path.textContent=s.path.length?s.path.length-1:"—";
+    document.querySelectorAll(".code-line").forEach(el=>el.classList.toggle("active",Number(el.dataset.line)===s.line));ui.play.textContent=timer?"❚❚ 暂停":"▶ 播放";
+  }
+  function pause(redraw=true){if(timer){clearInterval(timer);timer=null;}if(redraw&&frames.length)render();}
+  function play(){if(timer){pause();return;}if(index>=frames.length-1)index=0;timer=setInterval(()=>{if(index>=frames.length-1){pause();return;}index++;render();},Number(ui.speed.value));render();}
+  function move(delta){pause(false);index=Math.max(0,Math.min(frames.length-1,index+delta));render();}
+  function editCell(id){
+    if(mode==="start"){if(id!==map.goal&&!map.walls.has(id)){map.start=id;rebuild(true);}return;}
+    if(mode==="goal"){if(id!==map.start&&!map.walls.has(id)){map.goal=id;rebuild(true);}return;}
+    if(id===map.start||id===map.goal)return;if(paintToWall)map.walls.add(id);else map.walls.delete(id);rebuild(false);
+  }
+  ui.grid.addEventListener("pointerdown",e=>{const cell=e.target.closest(".cell");if(!cell)return;e.preventDefault();painting=true;const id=Number(cell.dataset.id);paintToWall=!map.walls.has(id);editCell(id);});
+  ui.grid.addEventListener("pointerover",e=>{if(!painting||mode!=="wall")return;const cell=e.target.closest(".cell");if(cell)editCell(Number(cell.dataset.id));});
+  window.addEventListener("pointerup",()=>painting=false);
+  ui.grid.addEventListener("keydown",e=>{if((e.key==="Enter"||e.key===" ")&&e.target.matches(".cell")){e.preventDefault();const id=Number(e.target.dataset.id);paintToWall=!map.walls.has(id);editCell(id);}});
+  document.querySelectorAll("[data-mode]").forEach(btn=>btn.addEventListener("click",()=>{mode=btn.dataset.mode;document.querySelectorAll("[data-mode]").forEach(x=>x.classList.toggle("active",x===btn));}));
+  $("[data-action=play]").addEventListener("click",play);$("[data-action=prev]").addEventListener("click",()=>move(-1));$("[data-action=next]").addEventListener("click",()=>move(1));
+  $("[data-action=reset]").addEventListener("click",()=>{map={start:DEFAULT.start,goal:DEFAULT.goal,walls:new Set(DEFAULT.walls)};rebuild(true);});
+  ui.timeline.addEventListener("input",()=>{pause(false);index=Number(ui.timeline.value);render();});ui.speed.addEventListener("change",()=>{if(timer){pause(false);play();}});
+  document.addEventListener("keydown",e=>{if(e.target.matches("input,select,button"))return;if(e.key==="ArrowRight")move(1);if(e.key==="ArrowLeft")move(-1);if(e.key===" "){e.preventDefault();play();}});
+  rebuild();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 这次更新解决什么

<!-- 说明读者问题、目标和范围。 -->

## 改动内容
- 在第 5 章新增“5.4 A* 寻路可视化”文章
- 讲解 `f(n) = g(n) + h(n)` 的基本含义
- 嵌入可交互的 A* 寻路演示
- 支持播放、暂停、单步、时间线、画墙以及移动起点和终点
- 使用 VitePress `withBase` 兼容 GitHub Pages 路径
- 完成移动端响应式适配
- <!-- 用一条可核验的结果描述本次改动。 -->

## 验证记录
- 内容校验通过
- 可视化静态检查 15/15 通过
- Edge 播放、暂停和单步操作正常
- 390px 手机视口无横向溢出
- 未发现页面脚本错误
<!-- 写实际执行的命令、Lab/示例结果，以及手工检查的页面。 -->

- [ ] `pnpm test`
- [ ] 涉及导航、主题、Markdown 渲染、base 或发布时：Pages 子路径 `pnpm run check:site` 与 `pnpm run test:pages`
- [ ] 新页面的导航、相对 `.md` 链接、公式、代码块和前后页跳转已检查
- [ ] 实际命令、结果与未执行项原因已写在本节

## 内容完成标准

- [ ] 学习目标、范围与成熟度状态清楚
- [ ] 定义、复杂度与边界行为已人工核验
- [ ] 示例或 Lab 已从头复现
- [ ] 引用可追溯，第三方素材许可清楚
- [ ] 正文、Lab、代码和测试术语一致
- [ ] 正文未硬编码 `/DSA-Mastery/`；相对 `.md` 链接目标存在
- [ ] Blocking review comments 已解决

## AI 使用与人工复核

<!-- 未使用可写“未使用”。如使用，说明用于什么、人工如何核验事实/代码/引用。 -->

## Reviewer 重点关注

<!-- 列出最不确定的判断、权衡或暂未覆盖内容。 -->

Closes #
