### PR TITLE
fix(site): expose Lab update guide in curriculum

### DIFF
--- a/.trellis/spec/content/frontmatter-and-routing.md
+++ b/.trellis/spec/content/frontmatter-and-routing.md
@@ -13,6 +13,8 @@ content/chapter-NN-slug/PP-page.md
   -> /learn/chapter-NN-slug/PP-page/
 content/chapter-preface/00-theory-environments.md
   -> /learn/chapter-preface/00-theory-environments/
+content/chapter-preface/01-lab-authoring-guide.md
+  -> /learn/chapter-preface/01-lab-authoring-guide/
 ```
 
 VitePress rewrite：
@@ -30,7 +32,7 @@ content/:chapter/:page.md -> learn/:chapter/:page/index.md
 - 章节目录：`chapter-NN-kebab-case`。
 - 页面文件：`PP-kebab-case.md`；`00-overview.md` 是章首页。
 - `NN` 必须等于 frontmatter `chapter` 的两位表示；`PP` 必须等于 `order` 的两位表示。
-- 唯一特殊章节固定为 `content/chapter-preface/00-theory-environments.md`；该目录必须恰好一篇教材，不允许用 `-1`、`99` 或重排数字章节模拟前言。
+- 唯一特殊章节目录固定为 `content/chapter-preface/`；其中按 `NN-kebab-case.md` 收录作者可在站内完整阅读的指南，不允许用 `-1`、`99` 或重排数字章节模拟前言。
 - 文件和目录只用小写英文字母、数字和连字符。
 
 每页必填：
@@ -40,7 +42,7 @@ content/:chapter/:page.md -> learn/:chapter/:page/index.md
 | `title` | 非空字符串；与唯一一级标题语义一致 |
 | `description` | 非空摘要，建议不超过 80 个汉字 |
 | `order` | 非负整数；同一章教材页面内唯一 |
-| `chapter` | 通常为与目录编号一致的非负整数；唯一前言页为字面量 `"preface"` |
+| `chapter` | 通常为与目录编号一致的非负整数；前言目录中的指南为字面量 `"preface"` |
 | `chapterTitle` | 非空；同章完全一致，不含章节编号 |
 | `updated` | 实质性修改日期，`YYYY-MM-DD` |
 | `contributors` | 非空字符串数组；记录实际写作或审阅者 |
@@ -61,7 +63,7 @@ content/:chapter/:page.md -> learn/:chapter/:page/index.md
 - 链接校验先排除带 URL scheme 或根路径的目标，再检查相对 `.md` 文件；因此 `https://host/guide.md` 不能被当作仓库相对文件。
 - `content/README.md`、仓库 README、`docs/**`、`.trellis/**` 不得成为课程页面。
 
-前言 frontmatter 固定为 `chapter: "preface"`、`order: 0`、`chapterTitle: "理论环境展示"`。数据层向界面同时输出内部 `chapter` 和展示用 `chapterLabel: "前言"`，正文、面包屑与侧栏禁止拼出“第 preface 章”。
+前言 frontmatter 固定为 `chapter: "preface"`、与两位文件前缀一致的 `order`、`chapterTitle: "课程作者指南"`。完整 Lab 手册由 `content/chapter-preface/01-lab-authoring-guide.md` 使用 VitePress include 复用 `docs/LAB_AUTHORING_GUIDE.md`，不得复制第二份正文。数据层向界面同时输出内部 `chapter` 和展示用 `chapterLabel: "前言"`，正文、面包屑与侧栏禁止拼出“第 preface 章”。
 
 ## 4. Validation & Error Matrix
 
@@ -71,8 +73,8 @@ content/:chapter/:page.md -> learn/:chapter/:page/index.md
 | status 不在允许集合 | 内容校验失败 |
 | 日期格式错误 | 内容校验失败 |
 | 路径编号与 chapter/order 不一致 | 内容校验失败 |
-| `chapter: "preface"` 出现在固定路径之外，或前言字段漂移 | 内容校验失败 |
-| 前言缺失、多于一页、排在 Ch.0 之后或泄露内部 id | artifact/Playwright 失败 |
+| `chapter: "preface"` 出现在固定目录之外，或前言字段漂移 | 内容校验失败 |
+| 前言缺少理论展示或 Lab 完整指南、排在 Ch.0 之后或泄露内部 id | artifact/Playwright 失败 |
 | 同章重复 order 或 chapterTitle 漂移 | 内容校验失败 |
 | 相对 `.md` 目标不存在、产物站内路由不存在 | validator 或 artifact check 失败 |
 | 手写 Pages base 或出现双 `/DSA-Mastery/` | 静态产物审计失败 |
@@ -81,7 +83,7 @@ content/:chapter/:page.md -> learn/:chapter/:page/index.md
 ## 5. Good / Base / Bad Cases
 
 - Good：`content/chapter-02-stack-queue/01-stack.md` 使用 `chapter: 2`、`order: 1`，并相对链接 `../../labs/chapter-02/lab-02-01-stack/README.md`。
-- Good：唯一展示页 `content/chapter-preface/00-theory-environments.md` 使用 `chapter: "preface"`，界面显示“前言”。
+- Good：`content/chapter-preface/00-theory-environments.md` 与 `01-lab-authoring-guide.md` 使用 `chapter: "preface"`，在“前言”章节目录中分别显示。
 - Base：`draft` 页面仍进入导航并显示状态徽章。
 - Bad：普通页面使用 `chapter: "preface"`、使用 `chapter: -1` 模拟前言、`contributors: "A"`、不存在的相对 `.md` 目标或硬编码 `/DSA-Mastery/learn/...`。
 
@@ -90,7 +92,7 @@ content/:chapter/:page.md -> learn/:chapter/:page/index.md
 - `pnpm run validate:content`：字段、路径、排序和相对 `.md` 目标。
 - 内容发现 fixture：在 `try/finally` 中创建一篇合规临时教材，确认校验、侧栏、数据加载、搜索和 build 都发现它，最后删除。
 - 静态产物审计：期望 URL 存在，链接只含一次 base。
-- 静态产物审计还要断言前言恰好一页、11 种理论块均已渲染、作者指南 URL 存在、前言位于 Ch.0 之前且不泄露 `preface` 内部标识。
+- 静态产物审计还要断言前言包含理论展示与完整 Lab 指南、11 种理论块均已渲染、include 已展开、前言位于 Ch.0 之前且不泄露 `preface` 内部标识。
 - Playwright：从首页实际点击进入教材页，并检查同源请求、控制台和页面错误；前言用桌面与 390px 视口覆盖章节顺序、搜索、面包屑、侧栏、代码交互和横向溢出。
 
 ## 7. Wrong vs Correct

--- a/.trellis/spec/frontend/vitepress-architecture.md
+++ b/.trellis/spec/frontend/vitepress-architecture.md
@@ -29,6 +29,10 @@ index.md / labs/index.md
 content/:chapter/:page.md       -> learn/:chapter/:page/index.md
 content/chapter-preface/00-theory-environments.md
                                 -> learn/chapter-preface/00-theory-environments/index.md
+content/chapter-preface/01-lab-authoring-guide.md
+                                -> learn/chapter-preface/01-lab-authoring-guide/index.md
+curriculum/outline/chapter-preface.md
+                                -> learn/outline/chapter-preface/index.md
 labs/:chapter/:lab/README.md    -> labs/:chapter/:lab/index.md
 outDir                         -> dist/pages
 ```
@@ -40,7 +44,7 @@ outDir                         -> dist/pages
 - `.vitepress/content-index.ts` 是结构化课程元数据、侧栏、首页统计、Labs 目录和文档头部的唯一索引；VitePress 原生搜索索引生成页，原生 prev/next 读取同一侧栏顺序，组件不得另建手写清单。
 - 未拆分的课程章节使用 `autoLabChapter` 从 ContentIndex 自动收录对应物理 chapter 的全部 Lab 到“相关 Labs”；不得用 `labSources` 维护一个会漏掉新增 Lab 的手写子集。只有同一物理 chapter 被编排为多个课程章节时，才使用显式 `labSources` 分流，并说明边界。
 - 当课程编排编号与既有文章 `chapter` 元数据不同时，`curriculum/**` 只提供入口和框架，`.vitepress/content-index.ts` 按 `sourcePath` 把唯一的已有 `CourseDocument` 映射进目标 Part/章节。不得移动、改写或复制 `content/**` 正文来适配新编排。
-- 前言是 ContentIndex 中唯一的非数字 `ChapterId`：固定为 `"preface"`，通过显式 `label: "前言"` 与 `chapterRank = -1` 排在 Ch.0 之前。它直接链接唯一展示页，不创建空 outline，也不改变数字章节编号。
+- 前言是 ContentIndex 中唯一的非数字 `ChapterId`：固定为 `"preface"`，通过显式 `label: "前言"` 与 `chapterRank = -1` 排在 Ch.0 之前。它使用真实章节 outline 列出理论环境展示和完整 Lab 更新指南；完整手册通过 include 复用 `docs` 单一事实来源，不改变数字章节编号。
 - Node `fs`、`path`、frontmatter 解析和文件遍历只在 config/data loader 构建期执行，不能进入浏览器 bundle。
 - `base` 从 `GITHUB_PAGES_BASE_PATH` 规范化：空值为 `/`；非空值首尾各一个斜杠。
 - 源码 URL 不含 base；Vue 链接使用 `withBase`。相对 `.md` 内容链接先由 validator 检查，再由 config 的 Markdown transform 按 `sourceUrlMap` 改写成 route。
@@ -57,7 +61,7 @@ outDir                         -> dist/pages
 | client bundle 含 `node:fs`/`node:path` | build 或 bundle 审计失败 |
 | base 缺首尾斜杠或出现双前缀 | artifact/Playwright 失败 |
 | rewrite 后旧课程 URL 不存在 | 兼容性测试失败 |
-| 前言通过负数/大数模拟、创建第二篇页面或改变数字章节 | 内容/架构检查失败 |
+| 前言通过负数/大数模拟、遗漏任一作者指南、复制手册正文或改变数字章节 | 内容/架构检查失败 |
 | repository-only Markdown 被构建 | 路由清单测试失败 |
 | 相对 `.md` 没有改写到课程 route | discovery/artifact check 失败 |
 | Part/章节只在组件中手写，或框架页复制已有正文 | 架构检查失败；改为 ContentIndex 编排映射 |
@@ -68,7 +72,7 @@ outDir                         -> dist/pages
 ## 5. Good / Base / Bad Cases
 
 - Good：config 和 loader 从同一收集器取得已排序条目；默认主题负责搜索与文档外壳，Vue 只消费序列化结果。
-- Good：前言定义使用 `{ number: 'preface', label: '前言', lessonSources: ['content/chapter-preface/00-theory-environments.md'] }`。
+- Good：前言定义使用 `/learn/outline/chapter-preface/`，并在 `lessonSources` 中显式列出理论展示和 Lab 更新指南两篇站内文章。
 - Base：本地开发没有环境变量，base 为 `/`。
 - Bad：组件调用 `import.meta.glob` 再建一份索引，或把 `/DSA-Mastery/` 拼进每个 URL。
 - Good：Ch.1 声明 `autoLabChapter: 1`，新增 `labs/chapter-01/lab-*` 后自动进入侧栏。
@@ -80,7 +84,7 @@ outDir                         -> dist/pages
 - `pnpm run test:discovery` 用临时教材/Lab 验证相对链接改写、MathJax、代码、表格、任务列表、导航、搜索和安全清理。
 - `pnpm run test:discovery` 还必须在启用 `autoLabChapter` 的现有章节创建临时 Lab，并从最终 HTML 的章节侧栏确认它自动出现，最后精确清理 fixture。
 - `pnpm run build && pnpm run check:site` 核对 ContentIndex 返回的全部教材/Lab、首页、Labs 索引、404、链接与恰好一个 base。
-- 前言产物检查使用 POSIX 化后的相对路径筛选；Windows 的 `path.join()` 会产生反斜杠，不能直接与 `learn/chapter-preface/` 比较。
+- 前言产物检查使用 POSIX 化后的相对路径筛选；断言两篇文章、章节 outline、站内搜索和侧栏入口全部存在。Windows 的 `path.join()` 会产生反斜杠，不能直接与 `learn/chapter-preface/` 比较。
 - 在 `/DSA-Mastery/` 下运行 `pnpm run test:pages`，真实点击五组场景并监控网络/控制台错误。
 - 编排变更必须断言每个 Part 的子章节、框架页面、至少一个映射后的旧文章 URL 和旧 Lab URL；同时用 `git diff -- content labs` 证明受保护内容未改动。
 
@@ -109,5 +113,13 @@ const url = `/learn/${chapterSlug}/${pageSlug}/`
 特殊前言的正确映射：
 
 ```ts
-{ number: 'preface', label: '前言', lessonSources: ['content/chapter-preface/00-theory-environments.md'] }
+{
+  number: 'preface',
+  label: '前言',
+  url: '/learn/outline/chapter-preface/',
+  lessonSources: [
+    'content/chapter-preface/00-theory-environments.md',
+    'content/chapter-preface/01-lab-authoring-guide.md',
+  ],
+}
 ```

--- a/.vitepress/content-index.ts
+++ b/.vitepress/content-index.ts
@@ -83,10 +83,13 @@ const curriculumChapterDefinitions: CurriculumChapterDefinition[] = [
     id: "chapter-preface",
     number: "preface",
     label: "前言",
-    title: "理论环境展示",
-    description: "在一篇真实文档中预览定义、定理、证明、行内语义与代码工作台。",
-    url: "/learn/chapter-preface/00-theory-environments/",
-    lessonSources: ["content/chapter-preface/00-theory-environments.md"],
+    title: "课程作者指南",
+    description: "查看理论文档语法，以及 Quiz、Program、Project 三类 Lab 的更新与测试流程。",
+    url: "/learn/outline/chapter-preface/",
+    lessonSources: [
+      "content/chapter-preface/00-theory-environments.md",
+      "content/chapter-preface/01-lab-authoring-guide.md",
+    ],
   },
   {
     id: "chapter-00-memory-foundations",
@@ -393,7 +396,7 @@ function createDocument(root: string, file: string, kind: DocumentKind): CourseD
     chapterLabel: chapterLabel(chapter),
     chapterTitle: text(
       parsed.data.chapterTitle,
-      chapter === "preface" ? "理论环境展示" : chapter === 0 ? "绪论" : `第 ${chapter} 章`,
+      chapter === "preface" ? "课程作者指南" : chapter === 0 ? "绪论" : `第 ${chapter} 章`,
     ),
     order: number(parsed.data.order),
     updated: text(parsed.data.updated, "未标注"),
@@ -471,7 +474,14 @@ export function collectCourseIndex(root = projectRoot): CourseIndex {
 
 export function createCourseSidebar(index: CourseIndex): DefaultTheme.SidebarItem[] {
   const chapterItem = (chapter: CurriculumChapter): DefaultTheme.SidebarItem => {
-    if (chapter.number === "preface") return { text: chapter.label, link: chapter.url };
+    if (chapter.number === "preface") {
+      return {
+        text: chapter.label,
+        link: chapter.url,
+        collapsed: false,
+        items: chapter.lessons.map((lesson) => ({ text: lesson.title, link: lesson.url })),
+      };
+    }
     return {
       text: `${chapter.label} ${chapter.title}`,
       link: chapter.url,

--- a/.vitepress/theme/components/CurriculumIndex.vue
+++ b/.vitepress/theme/components/CurriculumIndex.vue
@@ -46,7 +46,12 @@ const groups = computed(() => mode.value === "part" && currentPart.value
       <section class="course-curriculum-detail">
         <div>
           <h2>学习目标</h2>
-          <ul>
+          <ul v-if="currentChapter.number === 'preface'">
+            <li>统一理解课程理论文档与三类 Lab 的作者接口。</li>
+            <li>能够按规范创建、测试、评分和 Review 后续题目。</li>
+            <li>从站内完整指南直接复制经过自动验证的示例。</li>
+          </ul>
+          <ul v-else>
             <li>理解本章核心问题、数据表示与算法之间的联系。</li>
             <li>能够比较主要方案的适用条件与复杂度。</li>
             <li>通过已有文章与 Lab 建立可检查的学习成果。</li>
@@ -54,7 +59,12 @@ const groups = computed(() => mode.value === "part" && currentPart.value
         </div>
         <div>
           <h2>计划栏目</h2>
-          <ul v-if="currentChapter.number === '0+'">
+          <ul v-if="currentChapter.number === 'preface'">
+            <li>理论环境与 Markdown 语法展示</li>
+            <li>Quiz、Program、Project 更新机制</li>
+            <li>本地测试、CI、Review 与发布清单</li>
+          </ul>
+          <ul v-else-if="currentChapter.number === '0+'">
             <li>Peak Finding</li>
             <li>Union-Find</li>
             <li>数据结构的选择如何影响算法效率</li>

--- a/content/README.md
+++ b/content/README.md
@@ -7,7 +7,8 @@
 ```text
 content/
 ├── chapter-preface/
-│   └── 00-theory-environments.md
+│   ├── 00-theory-environments.md
+│   └── 01-lab-authoring-guide.md
 ├── chapter-00-introduction/
 │   ├── 00-overview.md
 │   ├── 01-data-structure-basics.md
@@ -22,7 +23,7 @@ content/
 ```
 
 - 章节目录使用 `chapter-NN-kebab-case`，其中 `NN` 为两位章节号。
-- 唯一例外是独立前言：固定使用 `chapter-preface/00-theory-environments.md`，不得在该目录增加第二篇页面。
+- 唯一例外是前言章节：使用 `chapter-preface/NN-kebab-case.md`，用于收录课程作者可直接阅读的完整指南。
 - 页面文件使用 `NN-kebab-case.md`；`00-overview.md` 是章首页，其余文件按阅读顺序编号。
 - 文件名和目录名只用小写英文字母、数字与连字符，避免空格和中文路径。
 - 新增页面后无需手写导航；构建程序应递归读取 `content/chapter-*/*.md`，再按 `chapter` 与 `order` 排序。
@@ -58,7 +59,7 @@ status: "draft"
 | `contributors` | 实际参与本页编写或审阅的成员列表 |
 | `status` | `draft`、`review` 或 `published` |
 
-前言展示页固定使用 `chapter: "preface"`、`order: 0`、`chapterTitle: "理论环境展示"`；这是作者展示用途的特殊标识，不是普通章节号，也不能复制到其他页面。
+前言页面固定使用 `chapter: "preface"`、与文件前缀一致的 `order`、`chapterTitle: "课程作者指南"`；这是作者指南用途的特殊标识，不是普通章节号，也不能复制到其他目录。
 
 ## 正文最低结构
 

--- a/content/chapter-preface/00-theory-environments.md
+++ b/content/chapter-preface/00-theory-environments.md
@@ -3,7 +3,7 @@ title: "前言 · 理论环境展示"
 description: "集中预览 DSA Mastery 理论文档中的正文、定义、定理、性质、证明、行内语义与代码工作台。"
 order: 0
 chapter: "preface"
-chapterTitle: "理论环境展示"
+chapterTitle: "课程作者指南"
 updated: "2026-08-17"
 contributors: ["Azen"]
 status: "draft"
@@ -191,4 +191,4 @@ int factorial(int n) {
 
 需要新增选择题、单题 C++ 作业或大型多任务 Lab 时，请使用统一的 Schema、`make run` 与评分工作流：
 
-**地址：** [`docs/LAB_AUTHORING_GUIDE.md`](https://github.com/AzenAnn/DSA-Mastery/blob/main/docs/LAB_AUTHORING_GUIDE.md)
+**站内阅读：** [Lab 更新与测试指南](./01-lab-authoring-guide.md)

--- a/content/chapter-preface/01-lab-authoring-guide.md
+++ b/content/chapter-preface/01-lab-authoring-guide.md
@@ -1,0 +1,12 @@
+---
+title: "Lab 更新与测试指南"
+description: "统一讲解 Quiz、Program、Project 三类 Lab 的创建、测试、评分、Review 与发布流程。"
+order: 1
+chapter: "preface"
+chapterTitle: "课程作者指南"
+updated: "2026-08-17"
+contributors: ["Azen"]
+status: "review"
+---
+
+<!--@include: ../../docs/LAB_AUTHORING_GUIDE.md-->

--- a/curriculum/outline/chapter-preface.md
+++ b/curriculum/outline/chapter-preface.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: "前言 · 课程作者指南"
+description: "从理论文档语法到三类 Lab 更新、测试与发布流程的统一作者入口。"
+status: "review"
+pageClass: dsa-curriculum-index
+---
+
+<CurriculumIndex />

--- a/docs/LAB_AUTHORING_GUIDE.md
+++ b/docs/LAB_AUTHORING_GUIDE.md
@@ -545,7 +545,7 @@ README-only Lab 继续正常渲染，不要求一次重写全部历史内容。�
 5. 执行 validate/verify、网站 discovery/build 和 Review。
 6. 在 PR 中记录未迁移 Lab 清单，不把“尚未迁移”伪装成错误。
 
-现有 6 个交互 Quiz 已迁移到 manifest；其他旧内容按 [旧 Lab 渐进迁移清单](LAB_MIGRATION_TRACKER.md)与章节更新节奏处理。
+现有 6 个交互 Quiz 已迁移到 manifest；其他旧内容按 [旧 Lab 渐进迁移清单](https://github.com/AzenAnn/DSA-Mastery/blob/main/docs/LAB_MIGRATION_TRACKER.md)与章节更新节奏处理。
 
 ## 12. 常见错误与正确做法
 

--- a/scripts/check-built-site.mjs
+++ b/scripts/check-built-site.mjs
@@ -156,10 +156,13 @@ if (complexityHtml.includes("::: definition") || dataStructureBasicsHtml.include
 const prefacePages = lessonPages.filter((relativePath) =>
   relativePath.replaceAll("\\", "/").startsWith("learn/chapter-preface/"),
 );
-if (prefacePages.length !== 1) {
-  throw new Error(`Preface must contain exactly one lesson page, found ${prefacePages.length}`);
+if (prefacePages.length !== 2) {
+  throw new Error(`Preface must contain the theory and Lab author guides, found ${prefacePages.length} pages`);
 }
-const prefaceHtml = await readFile(path.join(artifactRoot, prefacePages[0]), "utf8");
+const prefaceHtml = await readFile(
+  path.join(artifactRoot, "learn", "chapter-preface", "00-theory-environments", "index.html"),
+  "utf8",
+);
 for (const kind of [
   "definition",
   "theorem",
@@ -199,6 +202,25 @@ for (const required of [
 }
 if (prefaceHtml.includes("第 preface 章") || prefaceHtml.includes("::: definition")) {
   throw new Error("Preface leaked an internal chapter id or unparsed theory marker");
+}
+
+const labAuthorGuideHtml = await readFile(
+  path.join(artifactRoot, "learn", "chapter-preface", "01-lab-authoring-guide", "index.html"),
+  "utf8",
+);
+for (const required of [
+  "Lab 更新与测试指南",
+  "先选对 Lab 类型",
+  "make run",
+  "Golden Project",
+  "最终 Definition of Done",
+]) {
+  if (!labAuthorGuideHtml.includes(required)) {
+    throw new Error(`Rendered Lab author guide is missing: ${required}`);
+  }
+}
+if (labAuthorGuideHtml.includes("@include") || labAuthorGuideHtml.includes("第 preface 章")) {
+  throw new Error("Lab author guide was not expanded or leaked the internal preface id");
 }
 
 const curriculumHtml = await readFile(path.join(artifactRoot, "learn", "index.html"), "utf8");
@@ -243,7 +265,7 @@ if (base !== "/") {
 const searchableJavaScript = (
   await Promise.all(allFiles.filter((file) => file.endsWith(".js")).map((file) => readFile(file, "utf8")))
 ).join("\n");
-for (const searchTitle of ["前言 · 理论环境展示", "第 0 章 绪论", "Lab 01-02：实现并验证单链表"]) {
+for (const searchTitle of ["前言 · 理论环境展示", "Lab 更新与测试指南", "第 0 章 绪论", "Lab 01-02：实现并验证单链表"]) {
   if (!searchableJavaScript.includes(searchTitle)) throw new Error(`Local search bundle is missing: ${searchTitle}`);
 }
 

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -14,7 +14,7 @@ const requiredFields = [
   "status",
 ];
 const validStatuses = new Set(["draft", "review", "published"]);
-const prefaceLessonPath = "content/chapter-preface/00-theory-environments.md";
+const prefaceLessonPattern = /^content\/chapter-preface\/\d{2}-[a-z0-9-]+\.md$/;
 
 async function findFiles(root, predicate) {
   const results = [];
@@ -54,10 +54,10 @@ function assertFileContract(file, kind, parsed, seenOrder) {
   if (!/^\d+$/.test(parsed.data.order)) {
     throw new Error(`${relativePath}: order 必须是非负整数`);
   }
-  const isPrefaceLesson = kind === "lesson" && relativePath === prefaceLessonPath;
+  const isPrefaceLesson = kind === "lesson" && prefaceLessonPattern.test(relativePath);
   if (parsed.data.chapter === "preface") {
-    if (!isPrefaceLesson || parsed.data.order !== "0" || parsed.data.chapterTitle !== "理论环境展示") {
-      throw new Error(`${relativePath}: preface 仅允许用于唯一的前言理论环境展示页`);
+    if (!isPrefaceLesson || parsed.data.chapterTitle !== "课程作者指南") {
+      throw new Error(`${relativePath}: preface 仅允许用于 chapter-preface 下的课程作者指南`);
     }
   } else if (!/^\d+$/.test(parsed.data.chapter)) {
     throw new Error(`${relativePath}: chapter 必须是非负整数或受支持的 preface`);

--- a/scripts/validate-lab-docs.mjs
+++ b/scripts/validate-lab-docs.mjs
@@ -154,10 +154,18 @@ for (const relative of [
   "CONTRIBUTING.md",
   "docs/UPDATE_WORKFLOW.md",
   ".trellis/spec/content/index.md",
-  "content/chapter-preface/00-theory-environments.md",
 ]) {
   const source = await readFile(path.join(projectRoot, relative), "utf8");
   if (!source.includes("LAB_AUTHORING_GUIDE.md")) throw new Error(`${relative} 缺少 Lab 作者指南入口`);
+}
+
+const courseGuide = await readFile(path.join(projectRoot, "content/chapter-preface/01-lab-authoring-guide.md"), "utf8");
+if (!courseGuide.includes("../../docs/LAB_AUTHORING_GUIDE.md")) {
+  throw new Error("前言章节的 Lab 作者指南页面没有复用 docs/LAB_AUTHORING_GUIDE.md");
+}
+const prefaceShowcase = await readFile(path.join(projectRoot, "content/chapter-preface/00-theory-environments.md"), "utf8");
+if (!prefaceShowcase.includes("./01-lab-authoring-guide.md")) {
+  throw new Error("理论环境展示页缺少站内 Lab 更新与测试指南入口");
 }
 
 console.log(`Lab 文档检查通过：${jsonBlocks.length} 个语义化 JSON 示例、${commandLines.length} 条命令、${goldenLabs.length} 个 Golden Lab、${commands.length} 个 CLI 入口。`);

--- a/tests/pages-navigation.spec.mjs
+++ b/tests/pages-navigation.spec.mjs
@@ -216,6 +216,10 @@ test("local Chinese search finds lessons and Labs", async ({ page }) => {
   await expect(
     results.locator('a[href*="/learn/chapter-preface/00-theory-environments/"]').first(),
   ).toBeVisible();
+  await input.fill("Lab 更新与测试指南");
+  await expect(
+    results.locator('a[href*="/learn/chapter-preface/01-lab-authoring-guide/"]').first(),
+  ).toBeVisible();
   await input.fill("实现并验证单链表");
   const labResult = results.locator('a[href*="/labs/chapter-01/lab-01-02-linked-list/"]').first();
   await expect(labResult).toBeVisible();
@@ -270,21 +274,37 @@ test("curriculum exposes every Part and the required search, sorting, and algori
   expect(failures).toEqual([]);
 });
 
-test("preface is the first independent chapter and showcases every theory environment", async ({ page }) => {
+test("preface is the first author-guide chapter and exposes both complete guides", async ({ page }) => {
   const failures = monitorPage(page);
-  const route = `${baseUrl}/learn/chapter-preface/00-theory-environments/`;
+  const outlineRoute = `${baseUrl}/learn/outline/chapter-preface/`;
+  const showcaseRoute = `${baseUrl}/learn/chapter-preface/00-theory-environments/`;
+  const labGuideRoute = `${baseUrl}/learn/chapter-preface/01-lab-authoring-guide/`;
 
   await page.goto(`${baseUrl}/learn/`);
   const foundationChapters = page.locator(".course-curriculum-chapters > a");
   await expect(foundationChapters.first()).toContainText("前言");
-  await expect(foundationChapters.first()).toContainText("理论环境展示");
+  await expect(foundationChapters.first()).toContainText("课程作者指南");
   await expect(foundationChapters.nth(1)).toContainText("Ch.0");
   await foundationChapters.first().click();
 
-  await expect(page).toHaveURL(route);
+  await expect(page).toHaveURL(outlineRoute);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("课程作者指南");
+  const resources = page.locator(".course-curriculum-resource-list");
+  await expect(resources).toContainText("前言 · 理论环境展示");
+  const labGuideEntry = resources.getByRole("link", { name: /Lab 更新与测试指南/ });
+  await expect(labGuideEntry).toBeVisible();
+  await labGuideEntry.click();
+
+  await expect(page).toHaveURL(labGuideRoute);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Lab 更新与测试指南");
+  await expect(page.getByRole("heading", { level: 2, name: /先选对 Lab 类型/ })).toBeVisible();
+  await expect(page.locator(".vp-doc")).toContainText("Golden Project");
+  await expect(page.locator(".VPSidebar").getByRole("link", { name: "Lab 更新与测试指南", exact: true })).toBeVisible();
+
+  await page.goto(showcaseRoute);
   await expect(page.getByRole("heading", { level: 1 })).toHaveText("前言 · 理论环境展示");
   await expect(page.locator(".course-breadcrumbs").getByRole("link", { name: "前言" })).toBeVisible();
-  await expect(page.locator(".course-eyebrow")).toHaveText("前言 · 理论环境展示");
+  await expect(page.locator(".course-eyebrow")).toHaveText("前言 · 课程作者指南");
   await expect(page.locator("body")).not.toContainText("第 preface 章");
   await expect(page.locator(".VPSidebar").getByRole("link", { name: "前言", exact: true })).toBeVisible();
 
@@ -331,7 +351,7 @@ test("preface is the first independent chapter and showcases every theory enviro
 
   for (const width of [1440, 390]) {
     await page.setViewportSize({ width, height: 900 });
-    await page.goto(route);
+    await page.goto(showcaseRoute);
     const overflow = await page.evaluate(() =>
       globalThis.document.documentElement.scrollWidth - globalThis.window.innerWidth,
     );


### PR DESCRIPTION
## 变更内容

- 将“前言”从单一文章入口升级为真正的“课程作者指南”章节目录。
- 在课程目录、左侧导航和本地搜索中加入完整的“Lab 更新与测试指南”。
- 课程文章继续引用 `docs/LAB_AUTHORING_GUIDE.md` 作为正文单一事实来源，避免两份教程漂移。
- 更新内容发现、构建产物与浏览器导航回归测试，防止入口再次丢失。

## 根因

PR #21 只把作者指南放在 `docs/` 并从现有前言文章链接过去；课程发现器会排除 `docs/`，同时又把“前言”硬编码成单页，因此指南从未成为课程章节目录中的可见文章。

## 用户影响

课程首页点击“前言”后会进入“课程作者指南”目录；开发者可从目录或侧边栏直接打开完整的 Lab 更新、测试、评分和发布教程。

## 验证

- `pnpm test`
- GitHub Pages 子路径构建与产物检查（`/DSA-Mastery/`）
- Playwright 页面导航回归：14/14 通过
