### PR TITLE
test(site): align mobile sidebar title assertion

### DIFF
--- a/tests/pages-navigation.spec.mjs
+++ b/tests/pages-navigation.spec.mjs
@@ -586,7 +586,7 @@ test("mobile navigation exposes the course sidebar and top-level links", async (
 
   await page.locator(".VPLocalNav .menu").click();
   await expect(page.locator(".VPSidebar.open")).toBeVisible();
-  await expect(page.locator(".VPSidebar.open")).toContainText("1.2 顺序表");
+  await expect(page.locator(".VPSidebar.open")).toContainText("1.2 第一种实现——顺序表 (动态数组)");
   await expect(page.locator(".VPSidebar.open")).toContainText("1.3 第二种实现——链表与演进设计");
   await expect(page.locator(".VPSidebar.open")).toContainText("1.4 比较与权衡");
   await page.keyboard.press("Escape");


### PR DESCRIPTION
## Summary

- update the mobile sidebar Playwright assertion to match the current Chapter 1 sequential-list title
- unblock the GitHub Pages workflow without changing content discovery or site behavior

## Root cause

The lesson title changed from `1.2 顺序表` to `1.2 第一种实现——顺序表 (动态数组)`, but the mobile navigation test still asserted the old text. The built sidebar already contains Lab 01-09 through Lab 01-23; the stale assertion prevented that artifact from being deployed.

## Impact

The Pages workflow can validate and deploy the current automatically generated Lab sidebar. No course content, routing, or Lab indexing behavior changes.

## Validation

- Pages-base VitePress build passed with 39 Labs
- `pnpm run check:site` passed with 112 HTML files
- targeted mobile navigation test: 1 passed
- `pnpm run test:pages`: 15 passed
- `pnpm test`: passed; the existing Windows symlink test was skipped because local policy disallows creating test symlinks

## Review notes

This fix was diagnosed and implemented with AI assistance. Please verify that the asserted sidebar label remains aligned with `content/chapter-01-linear-list/02-sequential-list.md`.
