### PR TITLE
fix(theme): copy titled code blocks

### DIFF
--- a/.vitepress/markdown/theory.ts
+++ b/.vitepress/markdown/theory.ts
@@ -68,10 +68,8 @@ function addStandaloneCodeTitles(md: MarkdownIt): void {
       /^(<div class="[^"]+)/,
       "$1 dsa-code-block--titled",
     );
-    return titledWrapper.replace(
-      /(<span class="lang">[^<]*<\/span>)/,
-      `$1<span class="dsa-code-title" title="${escapedTitle}">${escapedTitle}</span>`,
-    );
+    const titleMarkup = `<span class="dsa-code-title" title="${escapedTitle}">${escapedTitle}</span>`;
+    return titledWrapper.replace(/(<\/pre>)/, `$1${titleMarkup}`);
   };
 }
 

--- a/tests/pages-navigation.spec.mjs
+++ b/tests/pages-navigation.spec.mjs
@@ -401,6 +401,9 @@ test("preface is the first author-guide chapter and exposes all complete guides"
   const copyButton = page.locator(".dsa-code-block--titled > button.copy").first();
   await copyButton.click();
   await expect(copyButton).toHaveClass(/copied/);
+  const copiedCode = await page.evaluate(() => navigator.clipboard.readText());
+  expect(copiedCode).toContain("#include <vector>");
+  expect(copiedCode).not.toContain("theory-environment-demo.cpp");
   const codeGroup = page.locator(".vp-code-group");
   await expect(codeGroup).toBeVisible();
   await expect(codeGroup.locator(".tabs label")).toHaveCount(2);


### PR DESCRIPTION
## Summary

- Preserve VitePress's `button.copy -> span.lang -> pre` DOM contract for titled code blocks.
- Render the optional filename after `<pre>` so copying targets the code instead of the filename.
- Add a browser regression assertion for clipboard content.

## Verification

- `pnpm test`
- 19/19 Pages navigation tests passed with the local Tabbit Chromium browser.
- Manual verification confirmed that a titled C++ block copies the code without the filename or line numbers.

## Review notes

The existing issue is reproduced by the new regression assertion on the pre-fix branch: the clipboard contained `theory-environment-demo.cpp`. After the fix it contains the C++ source.
