### PR TITLE
fix(labs): update contributors to czjLUCK for 17 ch5 labs

### DIFF
--- a/labs/chapter-05/lab-05-06-bst-insert-search/README.md
+++ b/labs/chapter-05/lab-05-06-bst-insert-search/README.md
@@ -5,7 +5,7 @@ order: 6
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "入门"

--- a/labs/chapter-05/lab-05-07-bst-delete/README.md
+++ b/labs/chapter-05/lab-05-07-bst-delete/README.md
@@ -5,7 +5,7 @@ order: 7
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "进阶"

--- a/labs/chapter-05/lab-05-08-validate-bst-preorder/README.md
+++ b/labs/chapter-05/lab-05-08-validate-bst-preorder/README.md
@@ -5,7 +5,7 @@ order: 8
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "进阶"

--- a/labs/chapter-05/lab-05-09-bst-kth-smallest/README.md
+++ b/labs/chapter-05/lab-05-09-bst-kth-smallest/README.md
@@ -5,7 +5,7 @@ order: 9
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "进阶"

--- a/labs/chapter-05/lab-05-10-avl-tree-insert/README.md
+++ b/labs/chapter-05/lab-05-10-avl-tree-insert/README.md
@@ -5,7 +5,7 @@ order: 10
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "挑战"

--- a/labs/chapter-05/lab-05-11-min-heap-implementation/README.md
+++ b/labs/chapter-05/lab-05-11-min-heap-implementation/README.md
@@ -5,7 +5,7 @@ order: 11
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "入门"

--- a/labs/chapter-05/lab-05-12-median-in-data-stream/README.md
+++ b/labs/chapter-05/lab-05-12-median-in-data-stream/README.md
@@ -5,7 +5,7 @@ order: 12
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "进阶"

--- a/labs/chapter-05/lab-05-13-task-scheduler/README.md
+++ b/labs/chapter-05/lab-05-13-task-scheduler/README.md
@@ -5,7 +5,7 @@ order: 13
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "进阶"

--- a/labs/chapter-05/lab-05-14-huffman-coding/README.md
+++ b/labs/chapter-05/lab-05-14-huffman-coding/README.md
@@ -5,7 +5,7 @@ order: 14
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "入门"

--- a/labs/chapter-05/lab-05-15-optimal-merge/README.md
+++ b/labs/chapter-05/lab-05-15-optimal-merge/README.md
@@ -5,7 +5,7 @@ order: 15
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "进阶"

--- a/labs/chapter-05/lab-05-16-k-ary-huffman/README.md
+++ b/labs/chapter-05/lab-05-16-k-ary-huffman/README.md
@@ -5,7 +5,7 @@ order: 16
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "挑战"

--- a/labs/chapter-05/lab-05-17-disjoint-set-union/README.md
+++ b/labs/chapter-05/lab-05-17-disjoint-set-union/README.md
@@ -5,7 +5,7 @@ order: 17
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "入门"

--- a/labs/chapter-05/lab-05-18-dynamic-connectivity/README.md
+++ b/labs/chapter-05/lab-05-18-dynamic-connectivity/README.md
@@ -5,7 +5,7 @@ order: 18
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "进阶"

--- a/labs/chapter-05/lab-05-19-food-chain-dsu/README.md
+++ b/labs/chapter-05/lab-05-19-food-chain-dsu/README.md
@@ -5,7 +5,7 @@ order: 19
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "挑战"

--- a/labs/chapter-05/lab-05-20-galaxy-heroes-dsu/README.md
+++ b/labs/chapter-05/lab-05-20-galaxy-heroes-dsu/README.md
@@ -5,7 +5,7 @@ order: 20
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "挑战"

--- a/labs/chapter-05/lab-05-21-btree-insertion/README.md
+++ b/labs/chapter-05/lab-05-21-btree-insertion/README.md
@@ -5,7 +5,7 @@ order: 21
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "进阶"

--- a/labs/chapter-05/lab-05-22-bplus-range-query/README.md
+++ b/labs/chapter-05/lab-05-22-bplus-range-query/README.md
@@ -5,7 +5,7 @@ order: 22
 chapter: 5
 chapterTitle: "树的应用"
 updated: "2026-08-25"
-contributors: ["Wanderer0"]
+contributors: ["czjLUCK"]
 status: "draft"
 lab: true
 difficulty: "挑战"


### PR DESCRIPTION
## 修复内容

将 Chapter 5 全部 17 道编程 Lab 的 `contributor` 字段统一修正为 `czjLUCK`。

之前 #83 中这些 Lab 的 contributor 被误标为其他名字，本次修正以确保署名准确。

## 受影响 Lab

`lab-05-06` ~ `lab-05-22` 共 17 个目录的 `README.md`：

- lab-05-06-sequential-search
- lab-05-07-binary-search
- lab-05-08-interpolation-search
- lab-05-09-bst-search
- lab-05-10-bst-insert
- lab-05-11-bst-delete
- lab-05-12-bst-kth-smallest
- lab-05-13-avl-tree
- lab-05-14-btree-search
- lab-05-15-btree-insert
- lab-05-16-btree-delete
- lab-05-17-hash-open-addressing
- lab-05-18-hash-chain
- lab-05-19-two-sum-hash
- lab-05-20-heap-kth-largest
- lab-05-21-union-find
- lab-05-22-huffman-encoding

## 验证

- [x] `pnpm test` 通过
- [x] `node tools/lab/cli.mjs verify` 全部 PASS
- [x] 仅修改 contributor 字段，无逻辑变更