### PR TITLE
Fix/ch01 student starters cleanup

### DIFF
--- a/.agents/skills/cleanup-lab-student-starters/SKILL.md
+++ b/.agents/skills/cleanup-lab-student-starters/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: cleanup-lab-student-starters
+description: "Cleans up complete solutions mistakenly placed in the student-code sections of DSA Mastery Labs (typically main.cpp under student/). Detects such Labs, resets each student starter to a compilable non-full skeleton, and verifies with the project's own checks. Use when a Lab's student starter has been filled with the reference solution, or to sweep all Labs."
+---
+
+你是 DSA Mastery 项目的 Lab 学生代码清理助手。目标：清理**所有** Lab 中「学生应完成部分」里误写入的完整题解代码，还原成「可编译、待学生补全」的骨架。
+
+## 背景与目标
+
+项目约定：Lab 的 `student/` 下是学生要补全的起始代码（starter），必须满足「可编译且非满分」；完整参考实现只存在于同目录 `solution/`。若某个 `student/main.cpp`（或 `student/`、`tasks/*/student/` 下的其它源文件）已被写成完整的可过题答案，会让 `lab:verify` 报「学生骨架分数：错误地得到满分」，也会让学生在测试/评测系统中直接拿到答案。
+
+## 工作流程
+
+1. **定位**：扫描 `labs/**/student/main.cpp`（含 `labs/**/tasks/*/student/main.cpp`）及 `student/` 下需要学生补全的其它源文件。只扫描、只改 `student/`，不碰 `solution/`、`tests/`、`README.md`、`lab.json`/`quiz.json`/`task.json`。
+
+2. **判定「误写完整解」**（优选权威信号，避免误判行数多的合法骨架）：
+   - 首选：对候选 Lab 运行 `pnpm lab:verify -- <lab-path>`；若输出含「**学生骨架分数：错误地得到满分**」，即完整解，需清理。
+   - 备选（当前无法编译/运行 verify 时）：比对 `student/main.cpp` 与同目录 `solution/main.cpp`；若 student 已把核心算法/判定/维护逻辑完整实现（而非用 `TODO` 留空），或与 solution 高度雷同，视为完整解。
+   - 注意：**行数多不等于完整解**（合法骨架可能含较多输入读取/数据结构脚手架，但核心逻辑仍是 TODO）。以「是否实现了本应留空的算法逻辑」为准。
+
+3. **清理成骨架**：
+   - 保留：必要的 `#include`、数据结构/类定义、`main()` 的输入读取与输出框架、以及说明「学生要实现什么」的 `TODO` 注释。
+   - 移除：本应由学生实现的核心算法逻辑（如逆置/删除/构造/平衡/查找/路径压缩/状态转移等），替换为对应位置的 `TODO` 注释。
+   - 若原文件没有可保留的 I/O 骨架，则参考 `solution/main.cpp` 的输入输出契约，构造一个结构一致、核心逻辑留空的最小骨架。
+   - 确保骨架能**编译通过**、输出不完整/非满分；风格对齐既有正常 skeleton（如 `labs/chapter-02/lab-02-04-min-stack/student/main.cpp`）。
+
+4. **复验**：对清理过的 Lab 重跑 `pnpm lab:verify -- <lab-path>`，确认变为「学生骨架编译：可编译」「学生骨架分数：未误得满分」；若影响结构再运行 `pnpm run validate:content` / `pnpm run test:lab-tools`。
+
+5. **报告**：列出扫描范围、判定为完整解的 Lab、每个文件的改动要点、实际执行的命令与结果、未复验项。
+
+## 安全与边界
+
+- **默认先 dry-run**：只扫描并输出「将改哪些文件、怎么改」的清单，经确认后再落盘修改；不要未经确认直接改写。
+- **范围**：默认清理**所有** Lab 中误写的完整题解，**包括**之前用于评测/测试的 Lab（如 `labs/chapter-01/lab-01-06-sequential-list-deduplication`）。除非通过参数显式指定排除清单，否则不留例外。
+- 只动 `student/`；不碰 `solution/`、`tests/`、`README.md`、manifest 或教材正文。
+- 不伪造运行结果：compiler、命令、退出码、verify 输出都如实记录。
+- 对难以安全还原的特殊骨架，明确标注「需人工判断」，不要硬改。
+
+## 输出格式（中文）
+
+- **结论**：扫描范围、判定为完整解的 Lab 数量。
+- **改动**：各 Lab 的文件与关键变化（保留/移除/新增哪些部分）。
+- **验证**：实际执行的 `lab:verify` 与其它检查的结果。
+- **风险**：未复验项、需人工判断的 Lab、剩余不确定性。
+
+## 参考
+
+- 完整解判定与验收标准见 `docs/LAB_AUTHORING_GUIDE.md`、`.trellis/spec/content/labs.md`（Program：reference=100、starter<100）。
+- 本地复现：`pnpm lab:run -- <lab-path>` / `pnpm lab:verify -- <lab-path>`。

--- a/labs/chapter-01/lab-01-09-singly-linked-list-reverse/student/main.cpp
+++ b/labs/chapter-01/lab-01-09-singly-linked-list-reverse/student/main.cpp
@@ -6,17 +6,9 @@ struct Node {
 };
 
 Node *reverselink(Node *head) {
-  Node *prv = nullptr;
-  Node *cur = head;
-  Node *nxt = nullptr;
-
-  while (cur != nullptr) {
-    nxt = cur->next;
-    cur->next = prv;
-    prv = cur;
-    cur = nxt;
-  }
-  return prv;
+  // TODO: 逆置单链表 head，返回新头节点。
+  // 要求：O(n) 时间，O(1) 额外空间，迭代实现（prev/curr/next 三指针）。
+  return head;
 }
 
 int main() {

--- a/labs/chapter-01/lab-01-10-singly-linked-list-remove-nth/student/main.cpp
+++ b/labs/chapter-01/lab-01-10-singly-linked-list-remove-nth/student/main.cpp
@@ -7,26 +7,10 @@ struct Node {
 };
 
 Node *deletekth(Node *head, int k) {
-  Node dummy = Node{0, head};
-  Node *fast = &dummy;
-  Node *slow = &dummy;
-
-  for (int i = 0; i < k; i++) {
-    fast = fast->next;
-  }
-
-  while (fast->next != nullptr) {
-    slow = slow->next;
-    fast = fast->next;
-  }
-  Node *temp = slow->next;
-  slow->next = slow->next->next;
-  delete temp;
-  /*if(cur->next!=nullptr){
-      nxt=cur->next;
-
-  }*/
-  return dummy.next;
+  // TODO: 删除单链表 head 的倒数第 k 个节点，返回新头节点。
+  // 要求：只遍历一次链表，O(1) 额外空间（dummy 头 + fast/slow 双指针）。
+  (void)k;
+  return head;
 }
 
 int main() {


### PR DESCRIPTION
## 这次更新解决什么

1. **新增 agent skill `cleanup-lab-student-starters`**（`.agents/skills/`）：用于自动清理各 Lab 中误写在 `student/`（学生应完成部分）里的完整题解，把 `lab:verify` 报「学生骨架分数：错误地得到满分」的 starter 还原成「可编译、待学生补全」的骨架。
2. **清理 `lab-01-09`、`lab-01-10`**：这两个 Lab 的 `student/main.cpp` 在 `main` 上就带着完整参考实现（`reverselink` / `deletekth` 已实现），学生可直接抄答案，也不符合「starter 可编译且非满分」约定。

## 改动内容

- 新增 `.agents/skills/cleanup-lab-student-starters/SKILL.md`（agent skill）。
- `lab-01-09-singly-linked-list-reverse/student/main.cpp`：`reverselink` 由完整实现改为 `TODO` 骨架（`return head`）；`include`/`struct Node`/`main()` 读入输出框架与 `main` 完全一致。
- `lab-01-10-singly-linked-list-remove-nth/student/main.cpp`：`deletekth` 由完整实现改为 `TODO` 骨架（`return head`）；其余与 `main` 完全一致。
- 未改动 `solution/`、`tests/`、`README.md`、manifest、其它 Lab 或教材。

## 验证记录

- [x] 新式 Lab：`pnpm lab:verify -- <lab-path>` × 2（01-09、01-10）：均 **PASS**

## 内容完成标准

- [x] 学习目标、范围与成熟度状态清楚
- [x] 定义、复杂度与边界行为已人工确认
- [x] Program reference=100、starter<100
- [x] 未硬编码 `/DSA-Mastery/`；相对 `.md` 链接目标存在

## AI 使用与人工复核

已使用：AI 以 `lab:verify` 的权威信号判定哪些 student 骨架是误写完整解、生成最小骨架并复验。人工需最终确认两个骨架的输入输出契约与题目一致；新增的 skill 是复用工具，建议 Reviewer 验证其 dry-run / 排除逻辑。

## Reviewer 重点关注

- 两个骨架只替换了核心函数体、其余与 `main` 完全一致，是否符合预期；
- 新增 skill 的「默认清理所有、可排除」策略是否符合团队预期。