### PR TITLE
fix(chapter-04): standardize lab numbers, add input guides, eliminate…

### DIFF
--- a/labs/chapter-04/lab-04-09-complete-binary-tree-check/README.md
+++ b/labs/chapter-04/lab-04-09-complete-binary-tree-check/README.md
@@ -26,10 +26,20 @@ duration: "20～30 分钟"
 3. 输出 `true` 或 `false`。
 
 ## 输入格式
-- 一行以空格分隔的若干个 token，表示二叉树的层序遍历序列，空节点使用 `null` 或 `#` 表示。
+- 一行以空格分隔的若干个 token，表示二叉树的层序遍历序列，空节点使用 `null` 表示。
 
 ## 输出格式
 - 输出一行：`true` 表示是完全二叉树，`false` 表示不是。
+
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
 
 ## 数据范围与限制
 | 项目 | 范围 |
@@ -88,10 +98,10 @@ true
 
 ```powershell
 # 运行评测
-pnpm lab:run -- labs/chapter-04/lab-04-01-complete-binary-tree-check
+pnpm lab:run -- labs/chapter-04/lab-04-09-complete-binary-tree-check
 
 # 单用例调试
-pnpm lab:run -- labs/chapter-04/lab-04-01-complete-binary-tree-check --case 001-sample
+pnpm lab:run -- labs/chapter-04/lab-04-09-complete-binary-tree-check --case 001-sample
 ```
 
 ## 题解
@@ -151,6 +161,40 @@ struct TreeNode {
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
 
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
 bool isCompleteTree(TreeNode* root) {
     if (!root) return true;
     std::queue<TreeNode*> q;
@@ -169,11 +213,23 @@ bool isCompleteTree(TreeNode* root) {
     }
     return true;
 }
+
+int main() {
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    std::cout << (isCompleteTree(root) ? "true" : "false") << "\n";
+    freeTree(root);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-01-complete-binary-tree-check
+pnpm lab:run -- labs/chapter-04/lab-04-09-complete-binary-tree-check
 ```

--- a/labs/chapter-04/lab-04-09-complete-binary-tree-check/solution/main.cpp
+++ b/labs/chapter-04/lab-04-09-complete-binary-tree-check/solution/main.cpp
@@ -14,7 +14,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -23,14 +23,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }

--- a/labs/chapter-04/lab-04-09-complete-binary-tree-check/student/main.cpp
+++ b/labs/chapter-04/lab-04-09-complete-binary-tree-check/student/main.cpp
@@ -17,7 +17,7 @@ int main() {
     std::ios::sync_with_stdio(false);
     std::cin.tie(nullptr);
 
-    // TODO: 读入层序序列构建二叉树，判断是否为完全二叉树并输出 YES 或 NO。
+    // TODO: 读入层序序列构建二叉树，判断是否为完全二叉树并输出 true 或 false。
     // 要求：基于 BFS 队列层序遍历判定，时间复杂度 O(n)，空间复杂度 O(n)。
     return 0;
 }

--- a/labs/chapter-04/lab-04-10-binary-tree-maximum-width/README.md
+++ b/labs/chapter-04/lab-04-10-binary-tree-maximum-width/README.md
@@ -18,7 +18,21 @@ duration: "25～35 分钟"
 
 ## 题目
 
-给定一棵二叉树，求其所有层中最大的层宽度。每一层的宽度定义为：该层最左端非空节点和最右端非空节点之间的节点数（包含中间的空节点）。
+## 输入格式
+- 一行以空格分隔的若干个 token，表示二叉树的层序遍历序列，空节点使用 `null` 表示。
+
+## 输出格式
+- 输出一个整数，表示二叉树的最大宽度。
+
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
 
 ## 数据范围与限制
 | 项目 | 范围 |
@@ -76,7 +90,7 @@ duration: "25～35 分钟"
 ## 如何验证
 
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-02-binary-tree-maximum-width
+pnpm lab:run -- labs/chapter-04/lab-04-10-binary-tree-maximum-width
 ```
 
 ## 题解
@@ -133,6 +147,40 @@ struct TreeNode {
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
 
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
 uint64_t widthOfBinaryTree(TreeNode* root) {
     if (!root) return 0;
     uint64_t maxWidth = 0;
@@ -155,11 +203,23 @@ uint64_t widthOfBinaryTree(TreeNode* root) {
     }
     return maxWidth;
 }
+
+int main() {
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    std::cout << widthOfBinaryTree(root) << "\n";
+    freeTree(root);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-02-binary-tree-maximum-width
+pnpm lab:run -- labs/chapter-04/lab-04-10-binary-tree-maximum-width
 ```

--- a/labs/chapter-04/lab-04-10-binary-tree-maximum-width/solution/main.cpp
+++ b/labs/chapter-04/lab-04-10-binary-tree-maximum-width/solution/main.cpp
@@ -16,7 +16,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -25,14 +25,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }

--- a/labs/chapter-04/lab-04-11-binary-tree-preorder-traversal/README.md
+++ b/labs/chapter-04/lab-04-11-binary-tree-preorder-traversal/README.md
@@ -28,11 +28,21 @@ duration: "15～20 分钟"
 
 ### 输入格式
 
-输入包含一行，为二叉树的层序序列（以空格分隔，`null` 或 `#` 表示空节点）。若输入为空树，则输入为单行 `null` 或空行。
+输入包含一行，为二叉树的层序序列（以空格分隔，`null` 表示空节点）。若输入为空树，则输入为单行 `null` 或空行。
 
 ### 输出格式
 
 输出一行，为二叉树前序遍历得到的节点值序列，以空格分隔。若树为空，则输出空行。
+
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
 
 ---
 
@@ -137,7 +147,7 @@ null
 #include <iostream>
 #include <vector>
 #include <string>
-#include <sstream>
+#include <queue>
 #include <stack>
 
 struct TreeNode {
@@ -150,22 +160,68 @@ struct TreeNode {
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
 
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size() && tokens[i] != "null") {
+            curr->left = new TreeNode(std::stoi(tokens[i]));
+            q.push(curr->left);
+        }
+        i++;
+        if (i < tokens.size() && tokens[i] != "null") {
+            curr->right = new TreeNode(std::stoi(tokens[i]));
+            q.push(curr->right);
+        }
+        i++;
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
 std::vector<int> preorderTraversal(TreeNode* root) {
     std::vector<int> res;
     if (root == nullptr) return res;
-
     std::stack<TreeNode*> st;
     st.push(root);
-
     while (!st.empty()) {
         TreeNode* node = st.top();
         st.pop();
         res.push_back(node->val);
-
         if (node->right != nullptr) st.push(node->right);
         if (node->left != nullptr)  st.push(node->left);
     }
     return res;
+}
+
+int main() {
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
+
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    std::vector<int> ans = preorderTraversal(root);
+    for (size_t i = 0; i < ans.size(); ++i) {
+        std::cout << ans[i] << (i + 1 == ans.size() ? "" : " ");
+    }
+    std::cout << "\n";
+    freeTree(root);
+    return 0;
 }
 ```
 

--- a/labs/chapter-04/lab-04-11-binary-tree-preorder-traversal/solution/main.cpp
+++ b/labs/chapter-04/lab-04-11-binary-tree-preorder-traversal/solution/main.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <vector>
 #include <string>
-#include <sstream>
 #include <queue>
 #include <stack>
 
@@ -16,7 +15,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -24,12 +23,12 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
     while (!q.empty() && i < tokens.size()) {
         TreeNode* curr = q.front();
         q.pop();
-        if (i < tokens.size() && tokens[i] != "null" && tokens[i] != "#") {
+        if (i < tokens.size() && tokens[i] != "null") {
             curr->left = new TreeNode(std::stoi(tokens[i]));
             q.push(curr->left);
         }
         i++;
-        if (i < tokens.size() && tokens[i] != "null" && tokens[i] != "#") {
+        if (i < tokens.size() && tokens[i] != "null") {
             curr->right = new TreeNode(std::stoi(tokens[i]));
             q.push(curr->right);
         }
@@ -61,14 +60,12 @@ std::vector<int> preorderTraversal(TreeNode* root) {
 }
 
 int main() {
-    std::string line;
-    if (!std::getline(std::cin, line) || line.empty()) {
-        return 0;
-    }
-    std::stringstream ss(line);
-    std::string token;
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
+
     std::vector<std::string> tokens;
-    while (ss >> token) {
+    std::string token;
+    while (std::cin >> token) {
         tokens.push_back(token);
     }
     TreeNode* root = buildTree(tokens);

--- a/labs/chapter-04/lab-04-12-binary-tree-level-and-zigzag-order/README.md
+++ b/labs/chapter-04/lab-04-12-binary-tree-level-and-zigzag-order/README.md
@@ -29,6 +29,16 @@ duration: "20～30 分钟"
 - 第一段输出 `LEVEL_ORDER:` 后跟标准层序遍历，每层占一行；
 - 第二段输出 `ZIGZAG_ORDER:` 后跟锯齿形层序遍历，每层占一行。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -115,6 +125,40 @@ struct TreeNode {
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
 
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
 void printLevelAndZigzag(TreeNode* root) {
     std::vector<std::vector<int>> levels;
     if (root) {
@@ -145,12 +189,26 @@ void printLevelAndZigzag(TreeNode* root) {
     std::cout << "ZIGZAG_ORDER:\n";
     for (size_t l = 0; l < levels.size(); l++) {
         auto lv = levels[l];
-        if (l % 2 == 1) std::reverse(lv.begin(), lv.end());
+        if (l % 2 == 1) {
+            std::reverse(lv.begin(), lv.end());
+        }
         for (size_t i = 0; i < lv.size(); i++) {
             std::cout << (i == 0 ? "" : " ") << lv[i];
         }
         std::cout << "\n";
     }
+}
+
+int main() {
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    printLevelAndZigzag(root);
+    freeTree(root);
+    return 0;
 }
 ```
 
@@ -158,5 +216,5 @@ void printLevelAndZigzag(TreeNode* root) {
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-03-binary-tree-level-and-zigzag-order
+pnpm lab:run -- labs/chapter-04/lab-04-12-binary-tree-level-and-zigzag-order
 ```

--- a/labs/chapter-04/lab-04-12-binary-tree-level-and-zigzag-order/solution/main.cpp
+++ b/labs/chapter-04/lab-04-12-binary-tree-level-and-zigzag-order/solution/main.cpp
@@ -15,7 +15,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -24,14 +24,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }

--- a/labs/chapter-04/lab-04-13-binary-tree-right-side-view/README.md
+++ b/labs/chapter-04/lab-04-13-binary-tree-right-side-view/README.md
@@ -26,6 +26,16 @@ duration: "20～30 分钟"
 ## 输出格式
 - 一行以空格分隔的整数，表示右视图节点值序列。若为空树输出空行。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -109,6 +119,40 @@ struct TreeNode {
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
 
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
 std::vector<int> rightSideView(TreeNode* root) {
     std::vector<int> res;
     if (!root) return res;
@@ -119,12 +163,30 @@ std::vector<int> rightSideView(TreeNode* root) {
         for (size_t i = 0; i < sz; i++) {
             TreeNode* node = q.front();
             q.pop();
-            if (i == sz - 1) res.push_back(node->val);
+            if (i == sz - 1) {
+                res.push_back(node->val);
+            }
             if (node->left) q.push(node->left);
             if (node->right) q.push(node->right);
         }
     }
     return res;
+}
+
+int main() {
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    auto res = rightSideView(root);
+    for (size_t i = 0; i < res.size(); i++) {
+        std::cout << (i == 0 ? "" : " ") << res[i];
+    }
+    std::cout << "\n";
+    freeTree(root);
+    return 0;
 }
 ```
 
@@ -132,5 +194,5 @@ std::vector<int> rightSideView(TreeNode* root) {
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-04-binary-tree-right-side-view
+pnpm lab:run -- labs/chapter-04/lab-04-13-binary-tree-right-side-view
 ```

--- a/labs/chapter-04/lab-04-13-binary-tree-right-side-view/solution/main.cpp
+++ b/labs/chapter-04/lab-04-13-binary-tree-right-side-view/solution/main.cpp
@@ -14,7 +14,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -23,14 +23,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }

--- a/labs/chapter-04/lab-04-14-construct-binary-tree-pre-in/README.md
+++ b/labs/chapter-04/lab-04-14-construct-binary-tree-pre-in/README.md
@@ -109,6 +109,7 @@ LEVELORDER: 1
 #include <iostream>
 #include <vector>
 #include <unordered_map>
+#include <queue>
 
 struct TreeNode {
     int val = 0;
@@ -135,8 +136,63 @@ TreeNode* helper(const std::vector<int>& preorder, int preL, int preR,
 
 TreeNode* buildTree(const std::vector<int>& preorder, const std::vector<int>& inorder) {
     std::unordered_map<int, int> inMap;
-    for (int i = 0; i < (int)inorder.size(); i++) inMap[inorder[i]] = i;
+    for (int i = 0; i < (int)inorder.size(); i++) {
+        inMap[inorder[i]] = i;
+    }
     return helper(preorder, 0, (int)preorder.size() - 1, inorder, 0, (int)inorder.size() - 1, inMap);
+}
+
+void postorder(TreeNode* root, std::vector<int>& res) {
+    if (!root) return;
+    postorder(root->left, res);
+    postorder(root->right, res);
+    res.push_back(root->val);
+}
+
+std::vector<int> levelorder(TreeNode* root) {
+    std::vector<int> res;
+    if (!root) return res;
+    std::queue<TreeNode*> q;
+    q.push(root);
+    while (!q.empty()) {
+        TreeNode* cur = q.front();
+        q.pop();
+        res.push_back(cur->val);
+        if (cur->left) q.push(cur->left);
+        if (cur->right) q.push(cur->right);
+    }
+    return res;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
+int main() {
+    int n;
+    if (!(std::cin >> n) || n <= 0) return 0;
+    std::vector<int> preorder(n), inorder(n);
+    for (int i = 0; i < n; i++) std::cin >> preorder[i];
+    for (int i = 0; i < n; i++) std::cin >> inorder[i];
+
+    TreeNode* root = buildTree(preorder, inorder);
+
+    std::vector<int> post;
+    postorder(root, post);
+    std::cout << "POSTORDER:";
+    for (int v : post) std::cout << " " << v;
+    std::cout << "\n";
+
+    std::vector<int> lvl = levelorder(root);
+    std::cout << "LEVELORDER:";
+    for (int v : lvl) std::cout << " " << v;
+    std::cout << "\n";
+
+    freeTree(root);
+    return 0;
 }
 ```
 
@@ -144,5 +200,5 @@ TreeNode* buildTree(const std::vector<int>& preorder, const std::vector<int>& in
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-05-construct-binary-tree-pre-in
+pnpm lab:run -- labs/chapter-04/lab-04-14-construct-binary-tree-pre-in
 ```

--- a/labs/chapter-04/lab-04-15-construct-binary-tree-in-post/README.md
+++ b/labs/chapter-04/lab-04-15-construct-binary-tree-in-post/README.md
@@ -98,6 +98,7 @@ LEVELORDER: 1
 #include <iostream>
 #include <vector>
 #include <unordered_map>
+#include <queue>
 
 struct TreeNode {
     int val = 0;
@@ -121,11 +122,72 @@ TreeNode* helper(const std::vector<int>& inorder, int inL, int inR,
     root->right = helper(inorder, inRoot + 1, inR, postorder, postL + leftSize, postR - 1, inMap);
     return root;
 }
+
+TreeNode* buildTree(const std::vector<int>& inorder, const std::vector<int>& postorder) {
+    std::unordered_map<int, int> inMap;
+    for (int i = 0; i < (int)inorder.size(); i++) {
+        inMap[inorder[i]] = i;
+    }
+    return helper(inorder, 0, (int)inorder.size() - 1, postorder, 0, (int)postorder.size() - 1, inMap);
+}
+
+void preorder(TreeNode* root, std::vector<int>& res) {
+    if (!root) return;
+    res.push_back(root->val);
+    preorder(root->left, res);
+    preorder(root->right, res);
+}
+
+std::vector<int> levelorder(TreeNode* root) {
+    std::vector<int> res;
+    if (!root) return res;
+    std::queue<TreeNode*> q;
+    q.push(root);
+    while (!q.empty()) {
+        TreeNode* cur = q.front();
+        q.pop();
+        res.push_back(cur->val);
+        if (cur->left) q.push(cur->left);
+        if (cur->right) q.push(cur->right);
+    }
+    return res;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
+int main() {
+    int n;
+    if (!(std::cin >> n) || n <= 0) return 0;
+    std::vector<int> inorder(n), postorder(n);
+    for (int i = 0; i < n; i++) std::cin >> inorder[i];
+    for (int i = 0; i < n; i++) std::cin >> postorder[i];
+
+    TreeNode* root = buildTree(inorder, postorder);
+
+    std::vector<int> pre;
+    preorder(root, pre);
+    std::cout << "PREORDER:";
+    for (int v : pre) std::cout << " " << v;
+    std::cout << "\n";
+
+    std::vector<int> lvl = levelorder(root);
+    std::cout << "LEVELORDER:";
+    for (int v : lvl) std::cout << " " << v;
+    std::cout << "\n";
+
+    freeTree(root);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-06-construct-binary-tree-in-post
+pnpm lab:run -- labs/chapter-04/lab-04-15-construct-binary-tree-in-post
 ```

--- a/labs/chapter-04/lab-04-16-flatten-binary-tree-to-linked-list/README.md
+++ b/labs/chapter-04/lab-04-16-flatten-binary-tree-to-linked-list/README.md
@@ -29,6 +29,16 @@ duration: "20～30 分钟"
 ## 输出格式
 - 输出一行展开后单链表的节点值序列，以空格分隔；若为空树输出 `<empty>`。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -101,6 +111,9 @@ null
 
 ```cpp
 #include <iostream>
+#include <vector>
+#include <string>
+#include <queue>
 
 struct TreeNode {
     int val = 0;
@@ -111,6 +124,41 @@ struct TreeNode {
     TreeNode(int x) : val(x) {}
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
+
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    while (root) {
+        TreeNode* next = root->right;
+        delete root;
+        root = next;
+    }
+}
 
 void flatten(TreeNode* root) {
     TreeNode* curr = root;
@@ -128,11 +176,36 @@ void flatten(TreeNode* root) {
         curr = curr->right;
     }
 }
+
+int main() {
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    flatten(root);
+    if (!root) {
+        std::cout << "<empty>\n";
+    } else {
+        bool first = true;
+        TreeNode* cur = root;
+        while (cur) {
+            if (!first) std::cout << " ";
+            std::cout << cur->val;
+            first = false;
+            cur = cur->right;
+        }
+        std::cout << "\n";
+    }
+    freeTree(root);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-07-flatten-binary-tree-to-linked-list
+pnpm lab:run -- labs/chapter-04/lab-04-16-flatten-binary-tree-to-linked-list
 ```

--- a/labs/chapter-04/lab-04-16-flatten-binary-tree-to-linked-list/solution/main.cpp
+++ b/labs/chapter-04/lab-04-16-flatten-binary-tree-to-linked-list/solution/main.cpp
@@ -14,7 +14,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -23,14 +23,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }

--- a/labs/chapter-04/lab-04-17-symmetric-tree/README.md
+++ b/labs/chapter-04/lab-04-17-symmetric-tree/README.md
@@ -26,6 +26,16 @@ duration: "15～25 分钟"
 ## 输出格式
 - 一行输出 `true` 或 `false`。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -82,6 +92,11 @@ true
 <summary>点击查看参考代码</summary>
 
 ```cpp
+#include <iostream>
+#include <vector>
+#include <string>
+#include <queue>
+
 struct TreeNode {
     int val = 0;
     TreeNode* left = nullptr;
@@ -92,6 +107,40 @@ struct TreeNode {
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
 
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
 bool check(TreeNode* p, TreeNode* q) {
     if (!p && !q) return true;
     if (!p || !q) return false;
@@ -101,11 +150,23 @@ bool check(TreeNode* p, TreeNode* q) {
 bool isSymmetric(TreeNode* root) {
     return check(root, root);
 }
+
+int main() {
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    std::cout << (isSymmetric(root) ? "true" : "false") << "\n";
+    freeTree(root);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-08-symmetric-tree
+pnpm lab:run -- labs/chapter-04/lab-04-17-symmetric-tree
 ```

--- a/labs/chapter-04/lab-04-17-symmetric-tree/solution/main.cpp
+++ b/labs/chapter-04/lab-04-17-symmetric-tree/solution/main.cpp
@@ -14,7 +14,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -23,14 +23,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }

--- a/labs/chapter-04/lab-04-18-subtree-of-another-tree/README.md
+++ b/labs/chapter-04/lab-04-18-subtree-of-another-tree/README.md
@@ -27,6 +27,16 @@ duration: "20～30 分钟"
 ## 输出格式
 - 输出一行 `true` 或 `false`。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -84,6 +94,11 @@ true
 <summary>点击查看参考代码</summary>
 
 ```cpp
+#include <iostream>
+#include <vector>
+#include <string>
+#include <queue>
+
 struct TreeNode {
     int val = 0;
     TreeNode* left = nullptr;
@@ -93,6 +108,40 @@ struct TreeNode {
     TreeNode(int x) : val(x) {}
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
+
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
 
 bool isSameTree(TreeNode* s, TreeNode* t) {
     if (!s && !t) return true;
@@ -105,11 +154,35 @@ bool isSubtree(TreeNode* root, TreeNode* subRoot) {
     if (isSameTree(root, subRoot)) return true;
     return isSubtree(root->left, subRoot) || isSubtree(root->right, subRoot);
 }
+
+int main() {
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
+
+    std::vector<std::string> tokens1, tokens2;
+    std::string token;
+    while (std::cin >> token) {
+        tokens1.push_back(token);
+        if (std::cin.peek() == '\n' || std::cin.peek() == '\r') break;
+    }
+    while (std::cin >> token) {
+        tokens2.push_back(token);
+    }
+
+    TreeNode* root = buildTree(tokens1);
+    TreeNode* subRoot = buildTree(tokens2);
+
+    std::cout << (isSubtree(root, subRoot) ? "true" : "false") << "\n";
+
+    freeTree(root);
+    freeTree(subRoot);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-09-subtree-of-another-tree
+pnpm lab:run -- labs/chapter-04/lab-04-18-subtree-of-another-tree
 ```

--- a/labs/chapter-04/lab-04-18-subtree-of-another-tree/solution/main.cpp
+++ b/labs/chapter-04/lab-04-18-subtree-of-another-tree/solution/main.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <vector>
 #include <string>
-#include <sstream>
 #include <queue>
 
 struct TreeNode {
@@ -15,7 +14,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -24,14 +23,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }
@@ -61,13 +60,18 @@ bool isSubtree(TreeNode* root, TreeNode* subRoot) {
 }
 
 int main() {
-    std::string line1, line2;
-    if (!std::getline(std::cin, line1) || !std::getline(std::cin, line2)) return 0;
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
+
     std::vector<std::string> tokens1, tokens2;
     std::string token;
-    std::stringstream ss1(line1), ss2(line2);
-    while (ss1 >> token) tokens1.push_back(token);
-    while (ss2 >> token) tokens2.push_back(token);
+    while (std::cin >> token) {
+        tokens1.push_back(token);
+        if (std::cin.peek() == '\n' || std::cin.peek() == '\r') break;
+    }
+    while (std::cin >> token) {
+        tokens2.push_back(token);
+    }
 
     TreeNode* root = buildTree(tokens1);
     TreeNode* subRoot = buildTree(tokens2);

--- a/labs/chapter-04/lab-04-19-sum-root-to-leaf-numbers/README.md
+++ b/labs/chapter-04/lab-04-19-sum-root-to-leaf-numbers/README.md
@@ -29,6 +29,16 @@ duration: "20～30 分钟"
 ## 输出格式
 - 输出一个整数，表示所有路径数字的总和。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -92,6 +102,11 @@ duration: "20～30 分钟"
 <summary>点击查看参考代码</summary>
 
 ```cpp
+#include <iostream>
+#include <vector>
+#include <string>
+#include <queue>
+
 struct TreeNode {
     int val = 0;
     TreeNode* left = nullptr;
@@ -102,15 +117,63 @@ struct TreeNode {
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
 
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
 int dfs(TreeNode* root, int prevSum) {
     if (!root) return 0;
     int sum = prevSum * 10 + root->val;
-    if (!root->left && !root->right) return sum;
+    if (!root->left && !root->right) {
+        return sum;
+    }
     return dfs(root->left, sum) + dfs(root->right, sum);
 }
 
 int sumNumbers(TreeNode* root) {
     return dfs(root, 0);
+}
+
+int main() {
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    std::cout << sumNumbers(root) << "\n";
+    freeTree(root);
+    return 0;
 }
 ```
 
@@ -118,5 +181,5 @@ int sumNumbers(TreeNode* root) {
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-10-sum-root-to-leaf-numbers
+pnpm lab:run -- labs/chapter-04/lab-04-19-sum-root-to-leaf-numbers
 ```

--- a/labs/chapter-04/lab-04-19-sum-root-to-leaf-numbers/solution/main.cpp
+++ b/labs/chapter-04/lab-04-19-sum-root-to-leaf-numbers/solution/main.cpp
@@ -14,7 +14,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -23,14 +23,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }

--- a/labs/chapter-04/lab-04-20-path-sum-all-paths/README.md
+++ b/labs/chapter-04/lab-04-20-path-sum-all-paths/README.md
@@ -27,6 +27,16 @@ duration: "25～35 分钟"
 ## 输出格式
 - 每行输出一条符合条件的路径，节点值之间用空格分隔；若无路径输出 `NONE`。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -87,7 +97,10 @@ NONE
 <summary>点击查看参考代码</summary>
 
 ```cpp
+#include <iostream>
 #include <vector>
+#include <string>
+#include <queue>
 
 struct TreeNode {
     int val = 0;
@@ -99,12 +112,48 @@ struct TreeNode {
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
 
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
 void dfs(TreeNode* root, int targetSum, std::vector<int>& curPath, std::vector<std::vector<int>>& res) {
     if (!root) return;
     curPath.push_back(root->val);
     targetSum -= root->val;
     if (!root->left && !root->right) {
-        if (targetSum == 0) res.push_back(curPath);
+        if (targetSum == 0) {
+            res.push_back(curPath);
+        }
     } else {
         dfs(root->left, targetSum, curPath, res);
         dfs(root->right, targetSum, curPath, res);
@@ -118,11 +167,42 @@ std::vector<std::vector<int>> pathSum(TreeNode* root, int targetSum) {
     dfs(root, targetSum, curPath, res);
     return res;
 }
+
+int main() {
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
+
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+        if (std::cin.peek() == '\n' || std::cin.peek() == '\r') break;
+    }
+    int targetSum = 0;
+    if (!(std::cin >> targetSum)) return 0;
+
+    TreeNode* root = buildTree(tokens);
+    auto paths = pathSum(root, targetSum);
+
+    if (paths.empty()) {
+        std::cout << "NONE\n";
+    } else {
+        for (const auto& p : paths) {
+            for (size_t i = 0; i < p.size(); i++) {
+                std::cout << (i == 0 ? "" : " ") << p[i];
+            }
+            std::cout << "\n";
+        }
+    }
+
+    freeTree(root);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-11-path-sum-all-paths
+pnpm lab:run -- labs/chapter-04/lab-04-20-path-sum-all-paths
 ```

--- a/labs/chapter-04/lab-04-20-path-sum-all-paths/solution/main.cpp
+++ b/labs/chapter-04/lab-04-20-path-sum-all-paths/solution/main.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <vector>
 #include <string>
-#include <sstream>
 #include <queue>
 
 struct TreeNode {
@@ -15,7 +14,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -24,14 +23,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }
@@ -71,15 +70,17 @@ std::vector<std::vector<int>> pathSum(TreeNode* root, int targetSum) {
 }
 
 int main() {
-    std::string line;
-    if (!std::getline(std::cin, line)) return 0;
-    int targetSum;
-    if (!(std::cin >> targetSum)) return 0;
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
 
     std::vector<std::string> tokens;
     std::string token;
-    std::stringstream ss(line);
-    while (ss >> token) tokens.push_back(token);
+    while (std::cin >> token) {
+        tokens.push_back(token);
+        if (std::cin.peek() == '\n' || std::cin.peek() == '\r') break;
+    }
+    int targetSum = 0;
+    if (!(std::cin >> targetSum)) return 0;
 
     TreeNode* root = buildTree(tokens);
     auto paths = pathSum(root, targetSum);

--- a/labs/chapter-04/lab-04-21-diameter-of-binary-tree/README.md
+++ b/labs/chapter-04/lab-04-21-diameter-of-binary-tree/README.md
@@ -26,6 +26,16 @@ duration: "20～30 分钟"
 ## 输出格式
 - 输出一个整数，表示二叉树的直径长度（边数）。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -94,6 +104,10 @@ duration: "20～30 分钟"
 <summary>点击查看参考代码</summary>
 
 ```cpp
+#include <iostream>
+#include <vector>
+#include <string>
+#include <queue>
 #include <algorithm>
 
 struct TreeNode {
@@ -105,6 +119,40 @@ struct TreeNode {
     TreeNode(int x) : val(x) {}
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
+
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
 
 int maxDepth(TreeNode* root, int& maxDia) {
     if (!root) return 0;
@@ -119,11 +167,23 @@ int diameterOfBinaryTree(TreeNode* root) {
     maxDepth(root, maxDia);
     return maxDia;
 }
+
+int main() {
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    std::cout << diameterOfBinaryTree(root) << "\n";
+    freeTree(root);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-12-diameter-of-binary-tree
+pnpm lab:run -- labs/chapter-04/lab-04-21-diameter-of-binary-tree
 ```

--- a/labs/chapter-04/lab-04-21-diameter-of-binary-tree/solution/main.cpp
+++ b/labs/chapter-04/lab-04-21-diameter-of-binary-tree/solution/main.cpp
@@ -15,7 +15,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -24,14 +24,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }

--- a/labs/chapter-04/lab-04-22-lowest-common-ancestor/README.md
+++ b/labs/chapter-04/lab-04-22-lowest-common-ancestor/README.md
@@ -28,6 +28,16 @@ duration: "25～35 分钟"
 ## 输出格式
 - 输出一个整数，表示最近公共祖先节点的值。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -89,6 +99,11 @@ duration: "25～35 分钟"
 <summary>点击查看参考代码</summary>
 
 ```cpp
+#include <iostream>
+#include <vector>
+#include <string>
+#include <queue>
+
 struct TreeNode {
     int val = 0;
     TreeNode* left = nullptr;
@@ -99,6 +114,40 @@ struct TreeNode {
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
 
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
+
 TreeNode* lowestCommonAncestor(TreeNode* root, int p, int q) {
     if (!root || root->val == p || root->val == q) return root;
     TreeNode* left = lowestCommonAncestor(root->left, p, q);
@@ -106,11 +155,35 @@ TreeNode* lowestCommonAncestor(TreeNode* root, int p, int q) {
     if (left && right) return root;
     return left ? left : right;
 }
+
+int main() {
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
+
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+        if (std::cin.peek() == '\n' || std::cin.peek() == '\r') break;
+    }
+    int p = 0, q = 0;
+    if (!(std::cin >> p >> q)) return 0;
+
+    TreeNode* root = buildTree(tokens);
+    TreeNode* lca = lowestCommonAncestor(root, p, q);
+
+    if (lca) {
+        std::cout << lca->val << "\n";
+    }
+
+    freeTree(root);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-13-lowest-common-ancestor
+pnpm lab:run -- labs/chapter-04/lab-04-22-lowest-common-ancestor
 ```

--- a/labs/chapter-04/lab-04-22-lowest-common-ancestor/solution/main.cpp
+++ b/labs/chapter-04/lab-04-22-lowest-common-ancestor/solution/main.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <vector>
 #include <string>
-#include <sstream>
 #include <queue>
 
 struct TreeNode {
@@ -15,7 +14,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -24,14 +23,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }
@@ -57,15 +56,17 @@ TreeNode* lowestCommonAncestor(TreeNode* root, int p, int q) {
 }
 
 int main() {
-    std::string line;
-    if (!std::getline(std::cin, line)) return 0;
-    int p, q;
-    if (!(std::cin >> p >> q)) return 0;
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
 
     std::vector<std::string> tokens;
     std::string token;
-    std::stringstream ss(line);
-    while (ss >> token) tokens.push_back(token);
+    while (std::cin >> token) {
+        tokens.push_back(token);
+        if (std::cin.peek() == '\n' || std::cin.peek() == '\r') break;
+    }
+    int p = 0, q = 0;
+    if (!(std::cin >> p >> q)) return 0;
 
     TreeNode* root = buildTree(tokens);
     TreeNode* lca = lowestCommonAncestor(root, p, q);

--- a/labs/chapter-04/lab-04-23-binary-tree-maximum-path-sum/README.md
+++ b/labs/chapter-04/lab-04-23-binary-tree-maximum-path-sum/README.md
@@ -28,6 +28,16 @@ duration: "30～45 分钟"
 ## 输出格式
 - 输出一个整数，表示最大路径和。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 样例
 
 ### 样例输入 1
@@ -90,6 +100,10 @@ duration: "30～45 分钟"
 <summary>点击查看参考代码</summary>
 
 ```cpp
+#include <iostream>
+#include <vector>
+#include <string>
+#include <queue>
 #include <algorithm>
 #include <climits>
 
@@ -102,6 +116,40 @@ struct TreeNode {
     TreeNode(int x) : val(x) {}
     TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
 };
+
+TreeNode* buildTree(const std::vector<std::string>& tokens) {
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
+    TreeNode* root = new TreeNode(std::stoi(tokens[0]));
+    std::queue<TreeNode*> q;
+    q.push(root);
+    size_t i = 1;
+    while (!q.empty() && i < tokens.size()) {
+        TreeNode* curr = q.front();
+        q.pop();
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->left = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->left);
+            }
+            i++;
+        }
+        if (i < tokens.size()) {
+            if (tokens[i] != "null") {
+                curr->right = new TreeNode(std::stoi(tokens[i]));
+                q.push(curr->right);
+            }
+            i++;
+        }
+    }
+    return root;
+}
+
+void freeTree(TreeNode* root) {
+    if (!root) return;
+    freeTree(root->left);
+    freeTree(root->right);
+    delete root;
+}
 
 int maxGain(TreeNode* node, int& maxSum) {
     if (!node) return 0;
@@ -117,11 +165,23 @@ int maxPathSum(TreeNode* root) {
     maxGain(root, maxSum);
     return maxSum;
 }
+
+int main() {
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::cin >> token) {
+        tokens.push_back(token);
+    }
+    TreeNode* root = buildTree(tokens);
+    std::cout << maxPathSum(root) << "\n";
+    freeTree(root);
+    return 0;
+}
 ```
 
 </details>
 
 ## 本地运行与提交
 ```powershell
-pnpm lab:run -- labs/chapter-04/lab-04-14-binary-tree-maximum-path-sum
+pnpm lab:run -- labs/chapter-04/lab-04-23-binary-tree-maximum-path-sum
 ```

--- a/labs/chapter-04/lab-04-23-binary-tree-maximum-path-sum/solution/main.cpp
+++ b/labs/chapter-04/lab-04-23-binary-tree-maximum-path-sum/solution/main.cpp
@@ -16,7 +16,7 @@ struct TreeNode {
 };
 
 TreeNode* buildTree(const std::vector<std::string>& tokens) {
-    if (tokens.empty() || tokens[0] == "null" || tokens[0] == "#") return nullptr;
+    if (tokens.empty() || tokens[0] == "null") return nullptr;
     TreeNode* root = new TreeNode(std::stoi(tokens[0]));
     std::queue<TreeNode*> q;
     q.push(root);
@@ -25,14 +25,14 @@ TreeNode* buildTree(const std::vector<std::string>& tokens) {
         TreeNode* curr = q.front();
         q.pop();
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->left = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->left);
             }
             i++;
         }
         if (i < tokens.size()) {
-            if (tokens[i] != "null" && tokens[i] != "#") {
+            if (tokens[i] != "null") {
                 curr->right = new TreeNode(std::stoi(tokens[i]));
                 q.push(curr->right);
             }

--- a/labs/chapter-04/lab-04-25-research-team-formation/README.md
+++ b/labs/chapter-04/lab-04-25-research-team-formation/README.md
@@ -239,14 +239,12 @@ int main() {
     vector<int> val(n + 1);
     for (int i = 1; i <= n; ++i) cin >> val[i];
 
-    // dp[u][j]：u子树中选j个节点（u必选）的最大价值
     vector<vector<int>> dp(n + 1, vector<int>(k + 1, INF));
 
     function<void(int)> dfs = [&](int u) {
         dp[u][1] = val[u];
         for (int v : adj[u]) {
             dfs(v);
-            // 倒序枚举j，避免重复
             for (int j = k; j >= 1; --j) {
                 if (dp[u][j] == INF) continue;
                 for (int t = 1; t <= k - j; ++t) {

--- a/labs/chapter-04/lab-04-26-communication-base-station/README.md
+++ b/labs/chapter-04/lab-04-26-communication-base-station/README.md
@@ -200,7 +200,6 @@ int main() {
         return 0;
     }
 
-    // BFS/DFS 找最远点
     auto bfs = [&](int src, vector<ll>& dist, vector<int>& parent, vector<int>& pw) {
         dist.assign(n + 1, -1);
         parent.assign(n + 1, -1);
@@ -224,28 +223,19 @@ int main() {
     vector<ll> dist;
     vector<int> parent, pw;
 
-    // 第一次：找 A
     bfs(1, dist, parent, pw);
     int A = 1;
-    for (int i = 1; i <= n; ++i) {
-        if (dist[i] > dist[A]) A = i;
-    }
+    for (int i = 1; i <= n; ++i) if (dist[i] > dist[A]) A = i;
 
-    // 第二次：找 B，记录路径
     bfs(A, dist, parent, pw);
     int B = A;
-    for (int i = 1; i <= n; ++i) {
-        if (dist[i] > dist[B]) B = i;
-    }
+    for (int i = 1; i <= n; ++i) if (dist[i] > dist[B]) B = i;
 
     ll D = dist[B];
     double halfD = D / 2.0;
 
-    // 从 B 回溯到 A，找中心
     vector<int> path;
-    for (int u = B; u != -1; u = parent[u]) {
-        path.push_back(u);
-    }
+    for (int u = B; u != -1; u = parent[u]) path.push_back(u);
 
     ll sum = 0;
     for (int i = 0; i < (int)path.size() - 1; ++i) {
@@ -253,12 +243,10 @@ int main() {
         int u = path[i + 1];
         int w = pw[v];
         if (sum + w == D / 2 && D % 2 == 0) {
-            // 中心恰好是节点 u
             cout << fixed << setprecision(2) << halfD << "\nNODE " << u << "\n";
             return 0;
         }
         if (sum + w > halfD) {
-            // 中心在边 (u, v) 内部
             double d = halfD - sum;
             cout << fixed << setprecision(2) << halfD << "\nEDGE ";
             if (u < v) cout << u << " " << v << " " << fixed << setprecision(2) << d << "\n";
@@ -268,7 +256,6 @@ int main() {
         sum += w;
     }
 
-    // 如果 B 就是中心（D=0 情况已处理）
     cout << fixed << setprecision(2) << halfD << "\nNODE " << B << "\n";
     return 0;
 }

--- a/labs/chapter-04/lab-04-27-longest-zigzag-path/README.md
+++ b/labs/chapter-04/lab-04-27-longest-zigzag-path/README.md
@@ -37,6 +37,16 @@ duration: "40～55 分钟"
 
 - 输出一个整数，表示最长之字形路径的边数。
 
+::: tip 💡 输入处理与建树指引
+1. **读入序列**：
+   直接使用 `std::string token; while (std::cin >> token)` 循环读取输入放入 `std::vector<std::string> tokens` 中即可，C++ 会自动按空格和换行分词。
+2. **字符串转数字与 null 拦截**：
+   - 遇到 `"null"` 时，表示空子树，直接将子节点置为 `nullptr`；**切勿对 `"null"` 调用 `std::stoi("null")`**（会抛出 `std::invalid_argument` 异常导致崩溃）；
+   - 仅在 `token != "null"` 时，才调用 `std::stoi(token)` 转为整数并创建有效节点 `new TreeNode(val)`。
+3. **基于队列的 BFS 建树**：
+   借助 `std::queue<TreeNode*>` 存放父节点，队头出队后依次连接左右孩子，并将非空孩子入队。
+:::
+
 ## 数据范围与限制
 
 | 项目 | 范围 |


### PR DESCRIPTION
## 这次更新解决什么

- **校准题号与命令路径**：解决第四章实验题号与前置理论选择题（`01~08`）错位的问题，将编程 Lab 统一顺延编排为 `lab-04-09` ～ `lab-04-28`，修复所有 `README.md` 中残留的历史路径与 `pnpm lab:run` / `make` 命令。
- **规范输入处理与防坑指引**：在所有二叉树实验文档中新增标准【输入处理与建树指引】提示框，引导读者使用 C++ 原生 `while (std::cin >> token)` 自动分词，并明确对 `"null"` 节点的前置拦截保护（避免直接调用 `std::stoi("null")` 触发 `std::invalid_argument` 异常导致崩溃）。
- **补全题解代码**：将所有的参考题解代码补全，现在包含完整的main以及必要函数，而不是之前的只含所需函数

## 改动内容

- 全面校对并更新 `labs/chapter-04/` 下全部 20 篇实验 `README.md` 的 Frontmatter 序号、主标题、输入指引及完整可运行参考代码。
- 重构第四章编程题 `solution/main.cpp`，消除 `sstream` 依赖并清理 `#` 判定，经评测内核全量验证满分通过。

## 验证记录

- [x] `pnpm test`
  - `validate:content`：63 篇教材页面，109 个 Lab，100 个新式 manifest，335 道交互选择题全部通过；
  - `typecheck` / `eslint`：0 错误，0 警告；
  - `test:lab-tools`：32 passed, 0 failed, 1 skipped；
  - `validate-lab-docs` / `test-content-discovery`：全部通过；
  - `vitepress build` & `check:site`：站点产物构建成功（219 个 HTML 页面）。
- [x] 新式 Lab：`pnpm lab:validate` 全部通过；Program/Project：`pnpm lab:verify -- labs/chapter-04/lab-04-09` ～ `lab-04-23` 全量执行通过。
- [x] 可执行 Lab 已记录操作系统、编译器/CMake 版本、自动分与人工待评分；构建后工作树无污染
  - 操作系统：Windows 11 (x64)
  - 环境版本：Node.js v24.19.0 / pnpm v11.1.1 / Clang++ (C++17)
  - 评测结果：参考实现 100/100，学生初始骨架可正常编译且未误得满分，标准输出无漂移。
- [x] Student pack（如适用）不含 `solution/`、缓存或二进制，并可脱离原仓库运行
- [x] 涉及导航、主题、Markdown 渲染、base 或发布时：Pages 子路径 `pnpm run check:site` 与 `pnpm run test:pages`
- [x] 新页面的导航、相对 `.md` 链接、公式、代码块和前后页跳转已检查
- [x] 实际命令、结果与未执行项原因已写在本节

## 内容完成标准

- [x] 学习目标、范围与成熟度状态清楚
- [x] 定义、复杂度与边界行为已人工核验
- [x] 示例或 Lab 已从头复现
- [x] Quiz 无 README 答案副本；Program reference=100、starter<100；Project 自动分与人工分分离
- [x] 引用可追溯，第三方素材许可清楚
- [x] 正文、Lab、代码和测试术语一致
- [x] 正文未硬编码 `/DSA-Mastery/`；相对 `.md` 链接目标存在
- [x] Blocking review comments 已解决

## AI 使用与人工复核

使用 AI 辅助编写批量重构脚本，完成第四章所有实验 `README.md` 的题号校正、输入处理指引生成以及 `solution/main.cpp` 的 `stringstream` 依赖剥离。人工对代码改动、`null` 与 `stoi` 边界处理、测试用例兼容性进行了核查，并通过全仓库 `pnpm test` 与 15 道 Lab 的 `lab:verify` 内核全量测试。

## Reviewer 重点关注

1. **输入处理的一致性**：二叉树层序序列输入统一使用 `while (std::cin >> token)` 读取；对于含有多行输入（如带有 `targetSum` 或节点值 `p, q`）的实验，已统一使用换行符截断处理，保证后续参数顺畅读入。

Closes #