### PR TITLE
docs(ch0): 第 0 章标题「内存基础」改为「基础」

### DIFF
--- a/.vitepress/content-index.ts
+++ b/.vitepress/content-index.ts
@@ -122,7 +122,7 @@ const curriculumChapterDefinitions: CurriculumChapterDefinition[] = [
   {
     id: "chapter-00-memory-foundations",
     number: "0",
-    title: "内存基础",
+    title: "基础",
     description: "从内存组织方式理解数据结构为何具有不同的表示与操作成本。",
     url: "/learn/outline/chapter-00-memory-foundations/",
     lessonSources: [

--- a/curriculum/outline/chapter-00-memory-foundations.md
+++ b/curriculum/outline/chapter-00-memory-foundations.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Ch.0 内存基础"
+title: "Ch.0 基础"
 description: "从内存组织方式理解数据结构的不同表示。"
 status: "draft"
 pageClass: dsa-curriculum-index


### PR DESCRIPTION
## 改动

将第 0 章标题从「内存基础」改为「基础」。

- `.vitepress/content-index.ts`：chapter-00 的 `title` 改为「基础」（侧栏显示「第 0 章 基础」）
- `curriculum/outline/chapter-00-memory-foundations.md`：页面标题改为「Ch.0 基础」
