### PR TITLE
修复测评输出末尾换行误判

### DIFF
--- a/.trellis/spec/content/lab-tooling.md
+++ b/.trellis/spec/content/lab-tooling.md
@@ -48,7 +48,7 @@ JSON 报告顶层：
 - 默认 C++17；只有题目明确需要且 README/CI 证明时可用 C++20。`toolchain.standard` 是直接编译和 Project CMake configure 的权威输入，CMakeLists 不得硬编码覆盖它。最低 GCC 11、Clang 14、MSVC 19.30；Project 另需 CMake 3.25。Dev Container/Codespaces 可选。
 - 所有 manifest 路径均为当前 Lab 内相对路径；拒绝绝对路径、`..`、缺失目标和符号链接逃逸。
 - Program 必须有可编译但不满分的 `student`、100 分 `solution`、合计 100 的 cases；stdout 判题、stderr 诊断。
-- 比较器与 oracle 写入都先统一 CRLF/LF；`.out` 固定写为 LF，`exact` 逐字符，`tokens` 按空白 token，`float` 对数值 token 使用 `absTol/relTol`。
+- 比较器与 oracle 写入都先统一 CRLF/LF；`.out` 固定写为 LF，`exact` 在此基础上逐字符比较但允许一侧缺少一个末尾 LF（不忽略内部换行、额外空行或其他空白），`tokens` 按空白 token，`float` 对数值 token 使用 `absTol/relTol`。
 - 判定固定为 `AC|WA|TLE|RE|CE|OLE|IE`；IE 不得伪装成学生 0 分。
 - 人类终端输出固定语义：AC/PASS/满分为 success，WA/CE/RE/IE/未满分实际分为 danger，TLE/OLE/PENDING 为 warning；未满分仍保留 `actual/maximum`，且 maximum 使用 success。颜色只增强文字，不得成为唯一状态信号。
 - Program 人类输出必须有逐 case 表格、PASS/NOT FULL 总结；失败时展示首差异和可复制单 case 重试。Project 必须分开 automated、manual pending、provisional total，并保持 task/case 层级。先 pad 原始单元格再加 ANSI，外部编译/CTest/stderr 正文不得被整块改色。

--- a/docs/LAB_AUTHORING_GUIDE.md
+++ b/docs/LAB_AUTHORING_GUIDE.md
@@ -360,11 +360,11 @@ lab-NN-LL-slug/
 
 ### 6.4 输出比较与判定
 
-所有模式先统一 CRLF/LF；`refresh-expected --write` 也固定把 `.out` 写为 LF，避免 Windows 与 Unix 作者反复制造换行 diff：
+所有模式先统一 CRLF/LF；`exact` 还允许两侧最多相差一个末尾 LF，但不忽略内部换行或其他空白。`refresh-expected --write` 固定把 `.out` 写为 LF，避免 Windows 与 Unix 作者反复制造换行 diff：
 
 | 模式 | 语义 | 适用场景 |
 | --- | --- | --- |
-| `exact` | 除平台换行外逐字符相等 | 输出格式本身是考点 |
+| `exact` | 除平台换行和一个可选末尾 LF 外逐字符相等；不忽略内部换行、额外空行或其他空白 | 输出格式本身是考点 |
 | `tokens` | Unicode 空白切 token 后逐项比较 | 普通算法题默认 |
 | `float` | 数值 token 按绝对/相对误差，其他 token 精确 | 数值计算 |
 

--- a/tests/lab-tools.test.mjs
+++ b/tests/lab-tools.test.mjs
@@ -179,6 +179,22 @@ test("output comparators normalize CRLF and support exact, tokens, and float tol
   assert.deepEqual(mismatch.difference, { kind: "token", index: 2, expected: "two", actual: "three" });
 });
 
+test("exact comparison accepts one optional final line break without hiding other differences", () => {
+  assert.equal(compareOutput("42\n", "42", { mode: "exact" }).equal, true);
+  assert.equal(compareOutput("42", "42\n", { mode: "exact" }).equal, true);
+  assert.equal(
+    classifyExecution(
+      { code: 0, stdout: "42", stderr: "", timedOut: false, outputExceeded: false },
+      "42\n",
+      { mode: "exact" },
+    ).verdict,
+    "AC",
+  );
+  assert.equal(compareOutput("42\n\n", "42\n", { mode: "exact" }).equal, false);
+  assert.equal(compareOutput("42\n43", "4243", { mode: "exact" }).equal, false);
+  assert.equal(compareOutput("42 ", "42", { mode: "exact" }).equal, false);
+});
+
 test("expected-output refresh renders a reviewable line diff", () => {
   assert.equal(previewDiff("one\ntwo\n", "one\nthree\n"), "@@ line 2 @@\n- two\n+ three");
 });

--- a/tools/lab/compare.mjs
+++ b/tools/lab/compare.mjs
@@ -2,6 +2,10 @@ export function normalizeNewlines(value) {
   return value.replace(/\r\n?/g, "\n");
 }
 
+function removeOptionalFinalLineBreak(value) {
+  return value.endsWith("\n") ? value.slice(0, -1) : value;
+}
+
 function locationAt(value, offset) {
   const before = value.slice(0, offset);
   const lines = before.split("\n");
@@ -13,8 +17,8 @@ function excerpt(value, offset) {
 }
 
 function exact(expected, actual) {
-  const left = normalizeNewlines(expected);
-  const right = normalizeNewlines(actual);
+  const left = removeOptionalFinalLineBreak(normalizeNewlines(expected));
+  const right = removeOptionalFinalLineBreak(normalizeNewlines(actual));
   if (left === right) return { equal: true };
   let index = 0;
   while (index < left.length && index < right.length && left[index] === right[index]) index += 1;


### PR DESCRIPTION
## 摘要

- 修复 Program Lab exact 比较器：输出与标准输出仅相差一个末尾换行时判定为 AC。
- 保留内部换行、额外空行、空格和其他字符差异的严格比较。
- 增加判题回归测试，并同步作者指南与 Lab 工具规范。

## 验证

- pnpm test：通过
- pnpm run test:lab-tools：34/34 通过
- pnpm run test:lab-docs：通过
- pnpm run test:lab-make：通过
- pnpm run lint：通过
- pnpm run typecheck：通过
- pnpm run test:lab-golden：当前环境未安装 CMake，返回 CMAKE_NOT_FOUND

## 关联 Issue

Closes #77

本 PR 相对 main 仅包含 4 个修复相关文件。