### PR TITLE
feat(labs): enforce stable document title contract

### DIFF
--- a/.trellis/spec/content/index.md
+++ b/.trellis/spec/content/index.md
@@ -13,5 +13,6 @@
 
 - 教材：`content/chapter-*/*.md`，明确排除 `content/README.md`。
 - Lab：`labs/chapter-*/lab-*/README.md`。
+- 新建 Lab，或由 Agent/作者整理既有 Lab README 时，必须从 `labId` 生成 `Lab CC-X-SS：题目名称`；不得使用 `order` 或旧目录序号重新编号。
 - 完整程序和测试放在对应 Lab 目录；正文只保留解释所需的关键片段。
 - 理论语义必须按[理论文档 Markdown 合同](../frontend/theory-markdown.md)选择；只做小范围人工迁移，不机械改写知识正文。

--- a/.trellis/spec/content/lab-tooling.md
+++ b/.trellis/spec/content/lab-tooling.md
@@ -47,6 +47,7 @@ JSON 报告顶层：
 
 - `lab.json` 是机器入口，`schemaVersion` 当前只接受整数 `1`，`type` 只接受 `quiz|program|project`。
 - README frontmatter 的 `labId` 是题目稳定身份：每章 `T/E/P` 分别从 01 追加，`lab:new` 使用同类最大序号加一且不复用缺号。新目录使用 `lab-NN-X-SS-slug`；存量旧目录保持可发现和可运行。
+- README 标题和 H1 由 `labId` 格式化为 `Lab CC-X-SS：题目名称`。脚手架、迁移工具和 Agent 不得用 `order` 或旧目录序号拼标题；存量旧目录允许保留 URL，并可只迁移标题。
 - `order` 与稳定 ID 分离：省略 `--order` 时脚手架追加到本章末尾，显式值只改变展示顺序。`lab:locate` 接受 `02T3` 等简写并返回规范 ID 与唯一路径。
 - 存量迁移只在 `chapter` 后插入 `labId`，必须复用该行实际的 `LF` 或 `CRLF`；不能根据文件任意位置出现的换行推断整份 README，否则混合换行历史文件会产生行尾空白 diff。
 - Windows 原生、Linux、macOS、WSL 使用同一 Node CLI；GNU Make 推荐但可选，`pnpm lab:run` 是 Windows 免 Make 官方兜底。
@@ -74,6 +75,7 @@ JSON 报告顶层：
 | --- | --- |
 | 向上找不到 `lab.json` | `LAB_NOT_FOUND`, exit 2 |
 | 稳定 ID 非法、不存在或重复 | `LAB_ID_INVALID` / `LAB_ID_NOT_FOUND` / `LAB_ID_DUPLICATE`, exit 2 |
+| 新式目录的标题不以其 `labId` 对应的 `Lab CC-X-SS：` 开头 | 内容校验失败；脚手架不得生成该状态 |
 | 迁移 README 缺少 `chapter`，或插入行引入异质换行 | `FRONTMATTER_INVALID` / `git diff --check` 失败，不得写入或提交 |
 | 未知 schema 主版本或坏 JSON | `SCHEMA_VERSION` / `JSON_INVALID`, exit 2 |
 | 路径越界或符号链接逃逸 | `PATH_ESCAPE`, exit 2 |

--- a/.trellis/spec/content/labs.md
+++ b/.trellis/spec/content/labs.md
@@ -33,6 +33,24 @@ Lab 继承教材八个字段，并额外要求：
 
 网站分类优先从同目录 `lab.json.type` 派生：`quiz -> theory`、`program -> exercise`、`project -> project`。稳定 ID 标签使用同一映射：`quiz -> T`、`program -> E`、`project -> P`。README-only Lab 由显式 `labCategory` 映射。有 manifest 的 Lab 不在 frontmatter 重复声明类型；分类随统一 ContentIndex 输出，侧栏不得维护第二份 Lab 清单。发布后的 `labId` 不因删除、插入或调整 `order` 而复用或改号。声明 `autoLabChapter` 的课程章节启用“本章 Labs”三分类并要求所有 Lab 可分类；即使集合为空，也显示 Theory/Exercise/Project 与各自空状态。当前 Ch.5 有 5 个正式 Quiz 和 17 个 Program，Theory 与 Exercise 分别显示对应的自动收录入口，Project 继续显示空状态；不得为填满空分类创建占位 Lab。未启用分类的章节继续使用“相关 Labs”。
 
+### 标题与稳定编号
+
+README 的源标题必须由 `labId` 生成，格式固定为 `Lab CC-X-SS：题目名称`。例如 `labId: "01E01"` 对应：
+
+```yaml
+title: "Lab 01-E-01：有序顺序表去重"
+```
+
+```md
+# Lab 01-E-01：有序顺序表去重
+```
+
+- frontmatter `title` 与正文 H1 必须完全一致；`CC`、`X`、`SS` 分别来自 `labId` 的章节、类型标签和类型内序号。
+- 新建 Lab，以及 Agent 或作者整理既有 Lab README 时，必须同步使用稳定标题；禁止从 `order`、旧目录中的 `lab-NN-OO` 或原来的 `Lab NN-OO` 标题推导编号。
+- 存量旧目录暂时不改名以保持 URL。未整理的旧标题可在过渡期继续通过校验；一旦迁移为稳定标题，不需要同时改目录。
+- 网站侧栏使用紧凑形式 `CCXSS · 题目名称`，例如 `01E01 · 有序顺序表去重`。这是展示格式，不得反向写进 README 标题。
+- 发布后修改题目名称时只改冒号后的文本；`labId` 和冒号前的稳定编号保持不变。
+
 README 至少说明：
 
 - 可检查的学习目标和前置知识；
@@ -96,6 +114,7 @@ README 至少说明：
 | 目录编号、chapter、order 不一致 | 内容校验失败 |
 | `labId` 缺失、重复、非规范形式、章节或类型标签不一致 | 内容校验失败 |
 | 新目录中的稳定编号与 `labId` 或标题不一致 | 内容校验失败 |
+| 新建或整理 Lab 时标题使用 `order`、旧目录序号，或 H1 与 frontmatter title 不一致 | 内容校验/Review blocking；改为 `Lab CC-X-SS：题目名称` |
 | 分类侧栏章节的 README-only Lab 缺 `labCategory`，或值非法 | 内容校验/构建失败 |
 | `lab` 不是布尔值 true | 内容校验失败 |
 | 缺 difficulty/duration | 内容校验失败 |

--- a/.trellis/spec/frontend/components-and-data.md
+++ b/.trellis/spec/frontend/components-and-data.md
@@ -51,7 +51,7 @@ type ContentEntry = {
 - 保留 VitePress 默认主题的顶栏、路由、local search、appearance、sidebar/mobile drawer、outline、prev/next、edit link、代码复制、语法高亮和 404，并用 `custom.css` 统一改色。
 - 只有课程元信息、教材/Lab 混合目录、品牌首页或默认主题无法表达的交互才写自定义组件。
 - 所有章节卡、Lab 卡、统计、sidebar、搜索和 prev/next 都从 ContentIndex 派生；不得在组件中手写七篇教材或四个 Lab。
-- Lab 分类同样由 ContentIndex 从 `lab.json.type` 或 README-only 的显式 `labCategory` 派生。稳定 ID 从 README `labId` 读取，并在 Lab 目录、详情元信息和侧栏中一致展示；组件不得从旧目录名或标题重新计算。侧栏条目统一显示为 `labId · 题目名称`，只在展示层移除旧标题中的 `Lab CC-NN：` 或 `Lab CC-T-NN：` 前缀，不重复展示两套编号，也不改动源标题、目录或 URL。声明 `autoLabChapter` 的章节侧栏按分类字段分组，但不得硬编码任何章节题目数组；零 Lab 时仍由同一数据流生成三类空状态。
+- Lab 分类同样由 ContentIndex 从 `lab.json.type` 或 README-only 的显式 `labCategory` 派生。稳定 ID 从 README `labId` 读取，并在 Lab 目录、详情元信息和侧栏中一致展示；组件不得从旧目录名或标题重新计算。README 的规范源标题为 `Lab CC-X-SS：题目名称`，侧栏条目统一显示为 `labId · 题目名称`。展示层在过渡期同时移除旧 `Lab CC-NN：` 与稳定 `Lab CC-X-SS：` 前缀，不重复展示两套编号，也不改动源标题、目录或 URL；旧前缀兼容只服务于尚未整理的存量文档，不能作为新内容模板。声明 `autoLabChapter` 的章节侧栏按分类字段分组，但不得硬编码任何章节题目数组；零 Lab 时仍由同一数据流生成三类空状态。
 - `chapter` 是排序与映射用的内部标识；所有用户可见章节名称读取 `chapterLabel` 或 curriculum `label`。特殊 `preface` 的标签必须是“前言”，数字章标签保持“第 N 章”或 curriculum 的 `Ch.N`。
 - 浏览器 API 只在挂载后访问；SSR 阶段不能直接读取 `window`、`document`、`localStorage`。
 - 普通内部导航使用 `withBase` 或 VitePress 生成链接。VitePress 1.6.4 的 Lab 跨页面 outline 兼容路径是例外：顶栏 Labs 与 Labs 目录卡片使用 `target="_self"` 触发同标签整页导航。

--- a/.trellis/workspace/Azen/index.md
+++ b/.trellis/workspace/Azen/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 18
-- **Last Active**: 2026-08-31
+- **Total Sessions**: 19
+- **Last Active**: 2026-09-01
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~453 | Active |
+| `journal-1.md` | ~474 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 19 | 2026-09-01 | 稳定 Lab 文档标题约束 | `5f0a637` | `codex/lab-stable-id` |
 | 18 | 2026-08-31 | Resolve PR 119 CI failures | `ead8db8`, `388cfe0` | `codex/lab-stable-id` |
 | 17 | 2026-08-31 | Normalize all Lab navigation labels | `90a26ca` | `codex/lab-stable-id` |
 | 16 | 2026-08-31 | Lab stable IDs and automatic numbering | `0bbec8e`, `e11f1f9`, `966557a`, `3a8c01e`, `5f0c328` | `codex/lab-stable-id` |

--- a/.trellis/workspace/Azen/journal-1.md
+++ b/.trellis/workspace/Azen/journal-1.md
@@ -451,3 +451,24 @@ Investigated GitHub Actions logs, updated stale stable-ID artifact assertions, s
 ### Status
 
 [OK] **Completed**
+
+
+## Session 19: 稳定 Lab 文档标题约束
+
+**Date**: 2026-09-01
+**Task**: 稳定 Lab 文档标题约束
+**Branch**: `codex/lab-stable-id`
+
+### Summary
+
+定义 README 标题从 labId 生成的统一格式，更新 Agent/作者约束、脚手架和渐进迁移校验，并新增旧目录稳定标题的自动发现回归。
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `5f0a637` | (see git log) |
+
+### Status
+
+[OK] **Completed**

--- a/docs/LAB_AUTHORING_GUIDE.md
+++ b/docs/LAB_AUTHORING_GUIDE.md
@@ -1,6 +1,6 @@
 # DSA Mastery Lab 更新与测试指南
 
-> 适用版本：Lab Schema v1 · 更新日期：2026-08-31
+> 适用版本：Lab Schema v1 · 更新日期：2026-09-01
 
 这份手册是 Quiz、Program 和 Project 三类 Lab 的统一作者 API。面向网页的说明仍写在 Lab 的 `README.md`，机器行为只由 `lab.json`、`quiz.json`、`cases.json`、`task.json` 和共享工具决定。后续开发者应从本文提供的脚手架开始，而不是复制旧 Lab 后自行发明目录、Make 规则或评分脚本。
 
@@ -149,6 +149,31 @@ labId: "02E07"
 
 `labId` 是题目的永久身份，`order` 只是网站展示顺序。发布后可以调整 `order`，不能修改或复用 `labId`。映射固定为 `quiz -> T`、`program -> E`、`project -> P`；README-only Lab 通过显式 `labCategory` 得到标签。现有旧目录保留以维持 URL，新建 Lab 才使用带标签的新目录格式。
 
+### 4.1 README 标题必须跟随稳定编号
+
+`labId` 使用便于交流和定位的紧凑形式，README 标题则使用带连字符的可读形式：
+
+| 位置 | 规范格式 | 示例 |
+| --- | --- | --- |
+| frontmatter `labId` | `CCXSS` | `01E01` |
+| frontmatter `title` | `Lab CC-X-SS：题目名称` | `Lab 01-E-01：有序顺序表去重` |
+| README H1 | 与 `title` 完全一致 | `# Lab 01-E-01：有序顺序表去重` |
+| 网站侧栏 | `CCXSS · 题目名称` | `01E01 · 有序顺序表去重` |
+
+作者或 Agent 新建 Lab、整理旧 Lab、重写题面时，只从 `labId` 构造标题。不要使用 `order`，也不要沿用旧目录中的顺序号：
+
+```yaml
+# Wrong：01-06 是旧展示顺序，不是题目身份
+labId: "01E01"
+title: "Lab 01-06：有序顺序表去重"
+
+# Correct
+labId: "01E01"
+title: "Lab 01-E-01：有序顺序表去重"
+```
+
+旧目录 `lab-01-06-sequential-list-deduplication` 可以继续保留，避免 URL 失效；只要同步修改 frontmatter `title` 和 H1，就能单独完成标题迁移。尚未整理的旧文档允许暂时保留旧标题，但不能复制成新模板。脚手架已经自动生成稳定标题，作者只替换冒号后的题目名称。
+
 最小公共 manifest：
 
 ```json
@@ -183,7 +208,7 @@ pnpm lab:new -- --type project --chapter 4 --slug tree-index
 pnpm lab:locate -- 02T2
 ```
 
-### 4.1 网站侧栏的分类接口
+### 4.2 网站侧栏的分类接口
 
 网站的 Lab 分类属于统一 `CourseIndex`，不是另一份手写导航。课程定义只要声明 `autoLabChapter`，侧栏就统一显示“本章 Labs”的三个分类；即使当前没有任何 Lab，也必须保留三类空槽位，不要在侧栏组件里复制 Lab 名单：
 

--- a/docs/LAB_CLI_COMMAND_GUIDE.md
+++ b/docs/LAB_CLI_COMMAND_GUIDE.md
@@ -177,7 +177,7 @@ node tools/lab/cli.mjs help
 pnpm lab:new -- --type program --chapter 2 --slug stack-merge
 ```
 
-假设第 2 章已有 `02E01`～`02E08`，这条命令会生成 `02E09`，目录为 `lab-02-E-09-stack-merge`。编号按“最大值加一”计算，删除 `02E04` 后也不会复用旧号。省略 `--order` 时，新 Lab 排在本章现有 Lab 之后；显式填写只改变展示位置，不改变稳定 ID。
+假设第 2 章已有 `02E01`～`02E08`，这条命令会生成 `02E09`，目录为 `lab-02-E-09-stack-merge`，README 标题以 `Lab 02-E-09：` 开头。编号按“最大值加一”计算，删除 `02E04` 后也不会复用旧号。省略 `--order` 时，新 Lab 排在本章现有 Lab 之后；显式填写只改变展示位置，不改变稳定 ID 或标题编号。
 
 三类编号互不占用：`quiz`、`program`、`project` 分别得到 `T`、`E`、`P` 标签，并在每章各自从 `01` 开始。并行分支可能同时拿到同一个下一个编号，CI 会拒绝重复 ID；后合并的分支同步 `main` 后重新创建即可。
 

--- a/scripts/test-content-discovery.mjs
+++ b/scripts/test-content-discovery.mjs
@@ -6,6 +6,12 @@ import { fileURLToPath } from "node:url";
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const lessonDirectory = path.join(projectRoot, "content", "chapter-99-discovery-fixture");
 const labDirectory = path.join(projectRoot, "labs", "chapter-99", "lab-99-E-01-discovery-fixture");
+const legacyStableTitleLabDirectory = path.join(
+  projectRoot,
+  "labs",
+  "chapter-99",
+  "lab-99-02-legacy-stable-title-fixture",
+);
 const sidebarLabDirectory = path.join(
   projectRoot,
   "labs",
@@ -149,6 +155,29 @@ duration: "1 分钟"
 - [ ] 页面、导航和搜索均包含本 Lab。
 `;
 
+const legacyStableTitleLab = `---
+title: "Lab 99-T-01：旧目录稳定标题验证"
+description: "验证旧目录无需改 URL，也能把 README 标题渐进迁移到稳定编号。"
+order: 2
+chapter: 99
+labId: "99T01"
+chapterTitle: "自动发现验证"
+updated: "2026-09-01"
+contributors: ["Discovery Test"]
+status: "draft"
+lab: true
+labCategory: theory
+difficulty: "测试"
+duration: "1 分钟"
+---
+
+# Lab 99-T-01：旧目录稳定标题验证
+
+## 验收标准
+
+- [ ] 旧目录与稳定标题可以在迁移期共存。
+`;
+
 const sidebarLab = `---
 title: "Lab 01-E-99：章节侧栏自动收录验证"
 description: "验证新增线性表 Lab 会自动进入本章 Labs 的实验分类。"
@@ -214,9 +243,15 @@ let primaryError;
 try {
   await mkdir(lessonDirectory, { recursive: true });
   await mkdir(labDirectory, { recursive: true });
+  await mkdir(legacyStableTitleLabDirectory, { recursive: true });
   await mkdir(sidebarLabDirectory, { recursive: true });
   await writeFile(path.join(lessonDirectory, "00-autodiscovery.md"), lesson, "utf8");
   await writeFile(path.join(labDirectory, "README.md"), lab, "utf8");
+  await writeFile(
+    path.join(legacyStableTitleLabDirectory, "README.md"),
+    legacyStableTitleLab,
+    "utf8",
+  );
   await writeFile(path.join(sidebarLabDirectory, "README.md"), sidebarLab, "utf8");
 
   runNpm(["run", "validate:content"]);
@@ -229,6 +264,18 @@ try {
   );
   const labHtml = await readFile(
     path.join(projectRoot, "dist", "pages", "labs", "chapter-99", "lab-99-E-01-discovery-fixture", "index.html"),
+    "utf8",
+  );
+  const legacyStableTitleLabHtml = await readFile(
+    path.join(
+      projectRoot,
+      "dist",
+      "pages",
+      "labs",
+      "chapter-99",
+      "lab-99-02-legacy-stable-title-fixture",
+      "index.html",
+    ),
     "utf8",
   );
   const sidebarLabHtml = await readFile(
@@ -320,6 +367,12 @@ try {
     throw new Error("Relative Markdown link was not rewritten to the Pages-aware Lab route");
   }
   if (!labHtml.includes("Lab 99-E-01：自动发现验证") || !labHtml.includes("99E01")) throw new Error("Temporary Lab page or stable ID was not generated");
+  if (
+    !legacyStableTitleLabHtml.includes("Lab 99-T-01：旧目录稳定标题验证") ||
+    !legacyStableTitleLabHtml.includes("99T01")
+  ) {
+    throw new Error("Legacy Lab directory did not accept a migrated stable document title");
+  }
   const searchFiles = (await filesRecursively(path.join(projectRoot, "dist", "pages")))
     .filter((file) => file.endsWith(".js"));
   const searchableJavaScript = (await Promise.all(searchFiles.map((file) => readFile(file, "utf8")))).join("\n");
@@ -396,12 +449,18 @@ try {
   assertFixtureTarget(lessonDirectory, path.join(projectRoot, "content"), "chapter-99-discovery-fixture");
   assertFixtureTarget(labDirectory, path.join(projectRoot, "labs", "chapter-99"), "lab-99-E-01-discovery-fixture");
   assertFixtureTarget(
+    legacyStableTitleLabDirectory,
+    path.join(projectRoot, "labs", "chapter-99"),
+    "lab-99-02-legacy-stable-title-fixture",
+  );
+  assertFixtureTarget(
     sidebarLabDirectory,
     path.join(projectRoot, "labs", "chapter-01"),
     "lab-01-E-99-sidebar-discovery-fixture",
   );
   await rm(lessonDirectory, { recursive: true, force: true });
   await rm(labDirectory, { recursive: true, force: true });
+  await rm(legacyStableTitleLabDirectory, { recursive: true, force: true });
   await rm(sidebarLabDirectory, { recursive: true, force: true });
   await rmdir(path.join(projectRoot, "labs", "chapter-99")).catch(() => {});
   try {

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -5,6 +5,7 @@ import {
   LAB_DIRECTORY_PATTERN,
   LEGACY_LAB_DIRECTORY_PATTERN,
   STABLE_LAB_DIRECTORY_PATTERN,
+  formatLabDocumentTitlePrefix,
   parseLabId,
   tagForCategory,
 } from "../tools/lab/identity.mjs";
@@ -113,7 +114,8 @@ function assertFileContract(file, kind, parsed, seenOrder, seenLabIds, labCatego
     if (!chapterMatch || Number(chapterMatch[1]) !== Number(parsed.data.chapter)) {
       throw new Error(`${relativePath}: chapter 目录必须与 frontmatter chapter 一致`);
     }
-    let expectedTitlePrefix;
+    const stableTitlePrefix = formatLabDocumentTitlePrefix(identity.id);
+    let allowedTitlePrefixes;
     if (legacyMatch) {
       if (
         Number(legacyMatch[1]) !== Number(parsed.data.chapter) ||
@@ -121,18 +123,23 @@ function assertFileContract(file, kind, parsed, seenOrder, seenLabIds, labCatego
       ) {
         throw new Error(`${relativePath}: 旧目录编号必须与 frontmatter chapter/order 一致`);
       }
-      expectedTitlePrefix = `Lab ${legacyMatch[1]}-${legacyMatch[2]}：`;
+      const legacyTitlePrefix = `Lab ${legacyMatch[1]}-${legacyMatch[2]}：`;
+      allowedTitlePrefixes = [stableTitlePrefix, legacyTitlePrefix];
     } else if (stableMatch) {
       const pathId = `${stableMatch[1]}${stableMatch[2]}${stableMatch[3]}`;
       if (pathId !== identity.id || Number(stableMatch[1]) !== Number(parsed.data.chapter)) {
         throw new Error(`${relativePath}: 新目录编号必须与 labId/chapter 一致`);
       }
-      expectedTitlePrefix = `Lab ${stableMatch[1]}-${stableMatch[2]}-${stableMatch[3]}：`;
+      allowedTitlePrefixes = [stableTitlePrefix];
     } else {
       throw new Error(`${relativePath}: Lab 目录名不符合旧路径或稳定 ID 路径约定`);
     }
-    if (!parsed.data.title.startsWith(expectedTitlePrefix)) {
-      throw new Error(`${relativePath}: title 必须以 ${expectedTitlePrefix} 开头`);
+    const matchedTitlePrefix = allowedTitlePrefixes.find((prefix) => parsed.data.title.startsWith(prefix));
+    if (!matchedTitlePrefix) {
+      throw new Error(`${relativePath}: title 必须以 ${allowedTitlePrefixes.join(" 或 ")} 开头`);
+    }
+    if (!parsed.data.title.slice(matchedTitlePrefix.length).trim()) {
+      throw new Error(`${relativePath}: title 的编号后必须包含题目名称`);
     }
     if (!parsed.body.includes(`# ${parsed.data.title}`)) {
       throw new Error(`${relativePath}: H1 必须与 frontmatter title 一致`);

--- a/tests/lab-tools.test.mjs
+++ b/tests/lab-tools.test.mjs
@@ -7,7 +7,14 @@ import { compareOutput } from "../tools/lab/compare.mjs";
 import { selectCompiler } from "../tools/lab/compiler.mjs";
 import { findLabRoot, loadLab, resolveLabPath, validateQuizQuestions, validateQuizReadme } from "../tools/lab/core.mjs";
 import { classifyExecution, judgeProgram } from "../tools/lab/judge.mjs";
-import { allocateLabIdentity, insertLabIdFrontmatter, locateLabById, normalizeLabId, parseLabId } from "../tools/lab/identity.mjs";
+import {
+  allocateLabIdentity,
+  formatLabDocumentTitlePrefix,
+  insertLabIdFrontmatter,
+  locateLabById,
+  normalizeLabId,
+  parseLabId,
+} from "../tools/lab/identity.mjs";
 import { runProcess } from "../tools/lab/process.mjs";
 import { createLab, THIN_MAKEFILE } from "../tools/lab/scaffold.mjs";
 import { cleanLab, packStudent, previewDiff, refreshExpected } from "../tools/lab/operations.mjs";
@@ -319,6 +326,7 @@ test("stable Lab IDs normalize common shorthand", () => {
   assert.equal(normalizeLabId("02-T-03"), "02T03");
   assert.equal(normalizeLabId("lab02-T-03"), "02T03");
   assert.deepEqual(parseLabId("02P12"), { id: "02P12", chapter: 2, tag: "P", sequence: 12 });
+  assert.equal(formatLabDocumentTitlePrefix("2e3"), "Lab 02-E-03：");
   assert.throws(() => normalizeLabId("02X03"), (error) => error.code === "LAB_ID_INVALID");
   assert.throws(() => normalizeLabId("02T0"), (error) => error.code === "LAB_ID_INVALID");
 });

--- a/tools/lab/identity.mjs
+++ b/tools/lab/identity.mjs
@@ -4,7 +4,7 @@ import matter from "gray-matter";
 import { LabError } from "./errors.mjs";
 import { formatLabId, normalizeLabId, parseLabId } from "./lab-id.mjs";
 
-export { formatLabId, normalizeLabId, parseLabId } from "./lab-id.mjs";
+export { formatLabDocumentTitlePrefix, formatLabId, normalizeLabId, parseLabId } from "./lab-id.mjs";
 
 export const LAB_TYPE_TO_TAG = Object.freeze({ quiz: "T", program: "E", project: "P" });
 export const LAB_TYPE_TO_CATEGORY = Object.freeze({ quiz: "theory", program: "exercise", project: "project" });

--- a/tools/lab/lab-id.mjs
+++ b/tools/lab/lab-id.mjs
@@ -45,3 +45,8 @@ export function parseLabId(value) {
 export function normalizeLabId(value) {
   return parseLabId(value).id;
 }
+
+export function formatLabDocumentTitlePrefix(value) {
+  const { chapter, tag, sequence } = parseLabId(value);
+  return `Lab ${padMinimum(chapter)}-${tag}-${padMinimum(sequence)}：`;
+}

--- a/tools/lab/scaffold.mjs
+++ b/tools/lab/scaffold.mjs
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { LabError } from "./errors.mjs";
 import { pathExists } from "./core.mjs";
-import { allocateLabIdentity } from "./identity.mjs";
+import { allocateLabIdentity, formatLabDocumentTitlePrefix } from "./identity.mjs";
 
 const projectRoot = path.resolve(import.meta.dirname, "../..");
 
@@ -17,8 +17,9 @@ function json(value) {
 function readme({ chapter, order, slug, type, identity }) {
   const code = `${pad(chapter)}-${identity.tag}-${pad(identity.sequence)}`;
   const names = { quiz: "选择题自测", program: "编程练习", project: "综合项目" };
+  const title = `${formatLabDocumentTitlePrefix(identity.id)}${names[type]}`;
   return `---
-title: "Lab ${code}：${names[type]}"
+title: "${title}"
 description: "请在发布前把这里替换为可检查的 Lab 学习成果。"
 order: ${order}
 chapter: ${chapter}
@@ -32,7 +33,7 @@ difficulty: "基础"
 duration: "45～60 分钟"
 ---
 
-# Lab ${code}：${names[type]}
+# ${title}
 
 ## 学习目标
 


### PR DESCRIPTION
## 变更内容

- 规定 README 标题和 H1 必须从 `labId` 生成：`Lab CC-X-SS：题目名称`
- 明确侧栏继续使用紧凑形式：`CCXSS · 题目名称`
- 新脚手架统一复用稳定标题格式化器
- 允许旧目录保留 URL，并逐篇迁移为稳定标题
- 增加旧目录搭配稳定标题的自动发现回归

## 迁移范围

本 PR 不批量改写现有 173 个 Lab 标题；未整理的旧标题继续兼容，后续 Agent 或作者整理 README 时按新约束迁移。

## 验证

- `pnpm run validate`
- `pnpm run test:lab-tools`
- `pnpm run test:lab-docs`
- `pnpm run test:discovery`