### PR TITLE
fix(theme): update homepage to reflect the student team

### DIFF
--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -36,7 +36,7 @@ function courseHref(path: string): string {
           </div>
           <h1>把数据结构与算法<br /><span>学透、做实、用活</span></h1>
           <p>
-            DSA Mastery 面向课程学习者，把定义、推导、实现、测试与典型问题训练连成一条完整路径，帮助读者建立能够应对课堂、考试、实验和综合应用的扎实能力。项目由两名学生共同维护，并通过交叉 Review 持续校正内容。
+            DSA Mastery 面向课程学习者，把定义、推导、实现、测试与典型问题训练连成一条完整路径，帮助读者建立能够应对课堂、考试、实验和综合应用的扎实能力。项目由一个近二十人的学生团队共同维护，并通过交叉 Review 持续校正内容。
           </p>
           <div class="course-hero-actions">
             <a class="course-button course-button-primary" :href="courseHref(firstLessonUrl)">


### PR DESCRIPTION
## 这次更新解决什么

首页 hero 文案仍写着"项目由**两名学生**共同维护"，与实际情况不符——项目现在由一支**近二十人的学生团队**共同维护。这处是公开介绍入口，表述过时会让读者/贡献者误判项目组织与维护规模。

## 改动内容

- `.vitepress/theme/components/HomePage.vue`：首页 hero 段文案
  - 原：`项目由两名学生共同维护，并通过交叉 Review 持续校正内容。`
  - 改：`项目由一个近二十人的学生团队共同维护，并通过交叉 Review 持续校正内容。`
- 仅此一处；README.md 已于此前合并时更新，`docs/` 内部协作表述不在本 PR 范围。

## 验证记录

- [x] 改动仅限首页 `.vue` 组件的一处字符串文案，无逻辑、无结构、无新页面、无 Lab、无链接变化。
- [x] 不涉及 frontmatter、相对 `.md` 链接、公式、代码块、导航或 base。

## 内容完成标准

- [x] 学习目标、范围与成熟度状态清楚（仅一处首页文案）
- [x] 未硬编码 `/DSA-Mastery/`；相对 `.md` 链接目标存在（本次不涉及）
- [x] 正文、Lab、代码和测试术语一致（未改教材/Lab）
- （其余条目本次不适用：未新增页面/Lab/定义/复杂度/引用。）

## AI 使用与人工复核

已使用：AI 定位并改写了首页过时的团队表述。人工需确认"近二十人的学生团队"措辞与实际团队规模一致。

## Reviewer 重点关注

- 首页文案是否属实、对外表述是否准确；
- 本次**只提交前端首页**。