### PR TITLE
feat(vscode-extension): support Project labs and judging

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -107,7 +107,9 @@ jobs:
             > [!WARNING]
             > **这是测试版，还没有经过充分的真实使用检验。** 判题链路、题解切除、进度状态机跑过验证，但界面部分测得不充分，预期会有 bug。遇到问题请提 Issue。
 
-            在 VSCode 中浏览、作答与提交 DSA Mastery 的 Lab：**73 道 Program（代码题）+ 38 道 Quiz（选择题）**。
+            在 VSCode 中浏览、作答与提交 DSA Mastery 的 Lab：**Program（代码题）、Project（项目题）和 Quiz（选择题）**。
+
+            Project 支持 stdio 与 CTest 自动判题；manual task 暂时显示 `PENDING`，不在插件内录入人工分数。
 
             ## 安装
 
@@ -127,8 +129,9 @@ jobs:
             | | 用途 |
             | --- | --- |
             | VSCode ≥ 1.90 | 插件 API 下限 |
-            | Node.js ≥ 22.13 | 运行判题内核（代码题需要） |
-            | C++ 编译器 | 编译答案（代码题需要）—— GCC ≥ 11、Clang ≥ 14 或 MSVC ≥ 19.30 |
+            | Node.js ≥ 22.13 | 运行判题内核（Program/Project 需要） |
+            | C++ 编译器 | 编译答案（Program/Project 需要）—— GCC ≥ 11、Clang ≥ 14 或 MSVC ≥ 19.30 |
+            | CMake ≥ 3.25 | 构建 Project 的 CTest task |
 
             选择题不需要 Node 和编译器。缺编译器时插件会提示并链到对应平台的安装指南。
 

--- a/.trellis/spec/quality/vscode-extension.md
+++ b/.trellis/spec/quality/vscode-extension.md
@@ -1,34 +1,65 @@
-# VS Code Extension Lab Identity and Progress Contract
+# VS Code Extension Lab Identity, Project and Progress Contract
 
 ## 1. Scope / Trigger
 
-适用于修改 `tools/vscode-extension/**` 中的 Lab 扫描、树视图、做题 WebView 导航、提交/统计状态或源码快照路径时。尤其适用于仓库 Lab 目录从平铺结构迁移到 `theory`、`exercise`、`project` 分类结构，或 README frontmatter 增加/调整 `labId` 时。
+适用于修改 `tools/vscode-extension/**` 中的 Lab 扫描、树视图、做题 WebView 导航、Project 文件入口、提交/统计状态或源码快照路径时。尤其适用于仓库 Lab 目录从平铺结构迁移到 `theory`、`exercise`、`project` 分类结构，或 README frontmatter 增加/调整 `labId` 时。
 
 ## 2. Signatures
 
 ```ts
-interface ProgramLab {
-  id: string;              // 稳定业务身份，如 01E01
-  name: string;            // 当前目录名，只用于资源定位
-  legacyNames: string[];   // 旧目录键别名
-  relativePath: string;    // 当前 Lab 路径，传给 lab CLI
+interface LabBase {
+  id: string;             // 稳定业务身份，如 01E01、01P01
+  name: string;           // 当前目录名，只用于资源定位/兼容解析
+  legacyNames: string[];  // 旧目录键别名
+  labPath: string;        // Lab 绝对路径
+  relativePath: string;   // 相对仓库根，传给 lab CLI
+  title: string;
+  chapter: number;
+  order: number;
 }
 
+type LabEntry = ProgramLab | QuizLab | ProjectLab;
+
 discoverProgramLabs(repoRoot: string): Promise<Chapter[]>;
-ProgressTracker.migrateLabKeys(labs: readonly ProgramLab[]): Promise<void>;
-remapRecordKeys<T>(source, aliases, merge): { records: Record<string, T>; changed: boolean };
-remapEventKeys<T extends { labName: string }>(source, aliases): { events: T[]; changed: boolean };
+ProgressTracker.migrateLabKeys(labs: readonly LabEntry[]): Promise<void>;
+scoreProject(repoRoot: string, labRelativePath: string): Promise<ProjectScoreResult>;
+ProgressTracker.getProject(labId: string): ProjectProgress | undefined;
+ProgressTracker.recordProjectSubmission(
+  lab: ProjectLab,
+  result: ProjectScoreResult,
+): Promise<ProjectProgress>;
+```
+
+Project 的结果类型必须保留以下可辨识层级：
+
+```ts
+ProjectScoreResult {
+  tasks: Array<
+    | { kind: "stdio"; judge: ScoreResult; status: Verdict; weight: number; weightedScore: number }
+    | { kind: "ctest"; tests: ProjectCtestResult[]; status: Verdict; weight: number; weightedScore: number }
+    | { kind: "manual"; status: "PENDING"; checklist: string[]; weight: number; weightedScore: 0 }
+  >;
+  automatedScore: number;
+  automatedMax: number;
+  manualPending: number;
+  provisionalTotal: number;
+  total: number;
+  automatedFull: boolean;
+  internalError: boolean;
+}
 ```
 
 ## 3. Contracts
 
 - 扫描 `labs/chapter-*/theory/`、`exercise/`、`project/` 下的直接 Lab 子目录；不存在的分类目录跳过。迁移过渡期可以读取章节目录下的旧平铺 Lab，但若新旧副本同时存在，优先分类目录并去重。
-- 只有 `lab.json.type` 为 `program` 或 `quiz` 且其运行数据有效的目录进入插件；README-only、坏 manifest、坏 quiz、无 student source 的目录跳过。`project` 的人工评审任务不能被当作自动判题题目。
+- `program`、`quiz` 和结构完整的 `project` 都进入插件。Project 顶层必须是 C++/CMake Project，task manifest 必须与顶层 `kind` 一致；README-only、坏 manifest、缺 task manifest、坏 task 数据或没有可解析运行数据的 Project 跳过，不阻塞其它 Lab。
 - 合法稳定编号匹配 `^\d{2}[TEP]\d{2,}$`，从 README frontmatter `labId` 读取。缺失或非法编号退回当前目录名，不用 `order` 推导稳定 ID。
-- `id` 是树命令参数、进度/Quiz key、活动事件值、章节统计索引和新源码快照目录名；`name`/`legacyNames` 只用于路径或兼容解析。判题 CLI 必须收到 `relativePath`，不能收到 `id`。
-- 进度 schema 3 兼容读取 schema 2；扫描完成后才执行目录键迁移。迁移前写入 `dsaMastery.progress.v1.backup.v<old>.<timestamp>`，成功后主记录使用稳定 ID。
-- 合并冲突时保留代码题的通过状态、最高分、最早通过时间、最近提交和按快照去重的历史；选择题按答案时间优先、同一时间再按尝试次数选择。历史快照按 `HistoryEntry.snapshot` 原路径读取，不批量搬动物理文件。
-- 树/WebView 展示稳定编号；标题中已有的 `Lab 01-E-01` 或 `Lab 01E01` 前缀不得再重复显示。命令解析和 WebView 导航接受 `id`、当前目录名和 `legacyNames`。
+- `id` 是树命令参数、进度 key、活动事件值和章节统计索引；`name`/`legacyNames` 只用于资源定位或兼容解析。判题 CLI 必须收到 `relativePath`，不能收到 `id`。
+- Project task 展示 `id`、相对路径、kind、weight、dependsOn；`stdio` 读取 task 的公开输入/期望输出，`ctest` 读取测试名称和分值，`manual` 读取 checklist 并显示 `PENDING`。学生文件只从当前 task 的 `student/` 下递归收集；不展示 `solution/`、`tests/`、`.lab-cache/` 或符号链接文件/目录作为作答入口。
+- Project 提交前只保存当前 Project 根目录内、且路径精确匹配已发现 `student/` 文件的 dirty 文档；不能调用 `workspace.saveAll()` 影响其它题目。之后调用 `node tools/lab/cli.mjs score <relativePath> --json`，由 CLI 负责 CMake、CTest、stdio 比较器、依赖和权重计算。
+- 进度 schema 3 继续兼容旧 Program/Quiz 状态；Project 使用独立 `dsaMastery.projectProgress.v1`，以 stable `labId` 为 key，只保存最近一次自动结果摘要和提交次数，不保存多文件源码快照或完整长输出。`resetAll()` 必须同时清理两张状态表。
+- 每次 Project 提交追加 `ActivityEvent` 的 `submit`；只有 `automatedFull && manualPending === 0 && !internalError` 才追加 `pass`、章节计数为已完成并显示最终完成状态。自动满分但存在 manual task 必须显示“自动通过 · 待人工”，不能伪造最终绿勾。
+- Project 不提供 Program 的单文件提交历史入口。直接调用历史命令时给出明确的多文件历史暂不支持提示；Program 的历史、快照迁移和 diff 行为保持不变。
 
 ## 4. Validation & Error Matrix
 
@@ -37,43 +68,54 @@ remapEventKeys<T extends { labName: string }>(source, aliases): { events: T[]; c
 | 分类目录不存在 | 跳过该分类，继续扫描其它分类 |
 | `labId` 缺失/非法 | 使用当前目录名作为身份，不抛异常 |
 | manifest 缺失/坏 JSON/不支持类型 | 跳过目录 |
-| quiz 数据损坏或 program 没有 student source | 跳过目录 |
+| Project manifest 缺少 `buildSystem: "cmake"`、task.json、必需 task 数据或出现不安全相对路径 | 跳过该 Project，不影响其它 Lab；提交时仍由 CLI 做权威校验 |
+| `student/` 本身或其子项是符号链接 | 不跟随、不收录其文件 |
+| Project CLI 顶层错误（如 `CMAKE_NOT_FOUND`、schema/path error） | 面板显示明确工具错误，不写入 ProjectProgress，不追加 pass |
+| Project task 返回 `IE` | 保留任务级结果，顶层显示评测内部错误，不追加 pass |
+| `stdio` task | 展示 `judge.cases[]`，包括 verdict、得分、耗时、stderr 和首处差异 |
+| `ctest` task | 展示命名测试的 verdict、得分、耗时和失败输出；构建失败时标记 CTest 未运行 |
+| `manual` task | 固定显示 `PENDING`、权重和 checklist；不计入 automated 分，不录入人工分 |
+| 自动部分满分且有 manual pending | 显示“自动通过 · 待人工”，不计入最终完成/通过 |
 | 新旧目录副本同时存在 | 分类目录优先，只保留一个 Lab |
-| 旧键与稳定键冲突 | 调用领域 merge，不能覆盖丢数据 |
-| 迁移持久化前 | 先保留完整 globalState 备份 |
-| 旧快照路径 | 保持 `HistoryEntry.snapshot`，不因重命名猜测或删除文件 |
+| 旧键与 stable 键冲突 | 调用领域 merge，不能覆盖丢数据；迁移前备份旧主状态 |
+| Project dirty 文件来自其它 Lab 或不在 `student/` | 不保存、不提交 |
 
 ## 5. Good / Base / Bad Cases
 
-- Good：`labs/chapter-01/exercise/E-01-01-foo/README.md` 声明 `labId: 01E01`，树/状态使用 `01E01`，CLI 使用 `labs/chapter-01/exercise/E-01-01-foo`。
-- Good：新分类目录和 `lab-01-06-foo` 暂时共存时，树只显示分类版本，旧进度键和活动事件合并到 `01E01`。
-- Base：旧平铺 Lab 没有 `labId` 时仍可被发现，身份退回目录名，待内容迁移后再获得稳定编号。
-- Bad：用 `order` 生成稳定 ID、把 `name` 写入新进度键，或把 `01E01` 作为 CLI 路径。
+- Good：`P-03-01` 进入树；面板显示 matcher 的 stdio cases、engine 的 CTest 名称和 report 的 `PENDING`，提交传入 `labs/chapter-03/project/P-03-01-string-match-engine`，结果保留 task → case/test 层级。
+- Good：自动结果 `Automated 80/80 + Manual pending 20` 时显示“自动通过 · 待人工”，章节完成数不增加。
+- Base：本机缺少 CMake 时 Project 仍可展示；提交由 CLI 返回 `CMAKE_NOT_FOUND`，扩展显示环境错误，Program/Quiz 不受影响。
+- Bad：把 Project 当成 `student/main.cpp`，只打开一个文件、压平 task 结果，或使用 `workspace.saveAll()` 保存其它题目的改动。
+- Bad：用 `lab.name` 做进度 key、把 `lab.id` 当 CLI 路径，或跟随 `student/` 符号链接读取 Project 外部文件。
 
 ## 6. Tests Required
 
 - 身份测试：合法、空值、非法 `labId` 回退；旧/新标题编号前缀去重。
-- 发现测试：三分类目录、旧平铺兼容、README-only/不支持类型过滤、过渡期新旧副本去重、stable ID 唯一性。
-- 迁移工具测试：多个旧键合并到稳定键、稳定记录不被覆盖、活动事件只改键不改顺序/其它字段。
-- 领域合并测试：代码题历史按 snapshot 去重且保留 latest/best/pass；Quiz 答案按时间和同刻尝试次数选择。
-- 每次修改后运行插件全量 `node --experimental-strip-types --test test/*.test.ts`、`tsc -p tsconfig.json --noEmit` 和 `node build.mjs`；若 pnpm 被依赖 build-script approval 拦截，记录该环境限制并直接运行等价脚本。
+- 发现测试：三分类目录、旧平铺兼容、README-only/不支持类型过滤、过渡期新旧副本去重、5 个真实 Project、三种 task 元数据、Project 学生文件分组和符号链接不跟随。
+- 迁移工具测试：多个旧键合并到稳定键、稳定记录不被覆盖、活动事件只改键不改顺序/其它字段；Project 使用独立 key。
+- Project 结果测试：保留 task → case/test 层级；manual 为 `PENDING`；自动满 + manual pending 不通过；IE 不追加 pass；长 CTest 输出不写入持久化摘要。
+- UI contract 测试：Project README、task/card、依赖、权重、学生文件入口、stdio case、CTest、PENDING、错误/差异输出和 Automated/Manual pending/Provisional total 都存在；Project 不出现 Program history 控件。
+- 每次修改后运行插件全量 `node --experimental-strip-types --test test/*.test.ts`、`tsc -p tsconfig.json --noEmit` 和 `node build.mjs`，并运行相关仓库门禁 `pnpm run validate`、`pnpm run test:lab-tools`、`pnpm test`；若 CMake 不可用，记录 `CMAKE_NOT_FOUND`，不能把环境失败写成代码通过。
 
 ## 7. Wrong vs Correct
 
 ### Wrong
 
 ```ts
-progress.get(lab.name);
+const source = path.join(lab.labPath, "student", "main.cpp");
+await vscode.workspace.saveAll();
 await scoreLab(repoRoot, lab.name);
 ```
 
-目录改名会让进度断开，且分类目录下 CLI 路径不完整。
+这会丢失 Project 的多 task 文件结构，保存其它 Lab 的改动，并把目录名误当成 CLI 路径。
 
 ### Correct
 
 ```ts
-progress.get(lab.id);
-await scoreLab(repoRoot, lab.relativePath);
+const files = lab.studentFiles.filter((file) => isOpenAndDirty(file.absolutePath));
+await Promise.all(files.map((file) => save(file.absolutePath)));
+const result = await scoreProject(repoRoot, lab.relativePath);
+await progress.recordProjectSubmission(lab, result);
 ```
 
-稳定 ID 管理用户状态，实际相对路径管理仓库资源和判题入口。
+学生文件入口来自扫描到的 `student/` 白名单，评分和聚合由既有 CLI 负责，状态以 stable `labId` 独立持久化。

--- a/docs/VSCODE_EXTENSION_GUIDE.md
+++ b/docs/VSCODE_EXTENSION_GUIDE.md
@@ -1,20 +1,21 @@
 # VSCode 插件：在编辑器里做题
 
-DSA Mastery 的 Program Lab 原本要在终端里判分。这个插件把代码题和选择题都带进 VSCode：左侧列出题目和完成状态，右侧显示题面，代码题可以提交判题，选择题可以直接作答并查看解析。
+DSA Mastery 的 Program/Project Lab 原本要在终端里判分。这个插件把代码题、项目题和选择题都带进 VSCode：左侧列出题目和完成状态，右侧显示题面，代码题和项目题可以提交判题，选择题可以直接作答并查看解析。
 
 ::: info 适用范围
-插件覆盖 **Program**（代码题）和 **Quiz**（四选一选择题）。Project 含人工评审环节，不在插件里，详见[范围与边界](#范围与边界)。
+插件覆盖 **Program**（代码题）、**Project**（多 task 项目题）和 **Quiz**（四选一选择题）。Project 的人工评审只保留 `PENDING` 占位，不在插件内录入人工分，详见[范围与边界](#范围与边界)。
 :::
 
 ## 安装
 
 ### 前置条件
 
-| 需要什么 | 为什么 | 代码题 | 选择题 |
-| --- | --- | :---: | :---: |
-| VSCode ≥ 1.90 | 插件用到的 API 下限 | 必需 | 必需 |
-| Node.js ≥ 22.13 | 运行判题内核 | 必需 | — |
-| C++ 编译器 | 编译你的答案（GCC ≥ 11、Clang ≥ 14 或 MSVC ≥ 19.30 三选一） | 必需 | — |
+| 需要什么 | 为什么 | Program | Project | Quiz |
+| --- | --- | :---: | :---: | :---: |
+| VSCode ≥ 1.90 | 插件用到的 API 下限 | 必需 | 必需 | 必需 |
+| Node.js ≥ 22.13 | 运行判题内核 | 必需 | 必需 | — |
+| C++ 编译器 | 编译你的答案（GCC ≥ 11、Clang ≥ 14 或 MSVC ≥ 19.30 三选一） | 必需 | 必需 | — |
+| CMake ≥ 3.25 | 构建 Project 的 CTest task | — | 必需 | — |
 
 **选择题只要 VSCode 就能做** —— 判定完全在插件内完成，不调用判题内核，也不需要编译器。
 
@@ -35,7 +36,7 @@ DSA Mastery 的 Program Lab 原本要在终端里判分。这个插件把代码�
 命令行安装也可以：
 
 ```bash
-code --install-extension ~/Downloads/dsa-mastery-labs-0.1.11.vsix
+code --install-extension ~/Downloads/dsa-mastery-labs-0.1.12.vsix
 ```
 
 ::: details 从源码构建（一般不需要）
@@ -46,7 +47,7 @@ cd DSA-Mastery/tools/vscode-extension
 pnpm install --ignore-workspace
 node build.mjs
 pnpm dlx @vscode/vsce package --no-dependencies --allow-missing-repository
-code --install-extension dsa-mastery-labs-0.1.11.vsix
+code --install-extension dsa-mastery-labs-0.1.12.vsix
 ```
 
 `pnpm install` 会因为没批准 esbuild 的 postinstall 而报一句 `ERR_PNPM_IGNORED_BUILDS`，可以忽略 —— esbuild 的可执行文件来自平台专属依赖，不跑那个脚本也能用。
@@ -60,7 +61,7 @@ VSCode 不会热加载新装的插件。装完请完全退出再打开。
 
 ### 确认装好了
 
-重启后打开 DSA Mastery 仓库根目录，活动栏（最左侧竖条）应出现 **DSA Mastery** 图标，点开后会按章节列出仓库中的全部 Program 和 Quiz Lab。
+重启后打开 DSA Mastery 仓库根目录，活动栏（最左侧竖条）应出现 **DSA Mastery** 图标，点开后会按章节列出仓库中的全部 Program、Project 和 Quiz Lab。
 
 如果图标没出现，在命令面板（<kbd>Cmd/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>）输入 `DSA`：
 
@@ -77,11 +78,11 @@ VSCode 不会热加载新装的插件。装完请完全退出再打开。
 
 打开侧边栏的 DSA Mastery，展开任一章节，点一道题：
 
-1. **题目面板打开**，显示题面、约束和全部测试用例（输入与期望输出都可见）。
-2. 点 **打开答题文件**，在旁边打开 `student/main.cpp`。
+1. **题目面板打开**，显示题面；Program 还会显示公开测试用例，Project 会显示 task 图、依赖、权重和学生文件。
+2. 点 **打开答题文件**（Project 中也可以在 task 卡片里选择文件），在旁边打开学生文件。
 3. 写你的实现。
-4. 点 **提交**。插件会先保存文件、检查环境，然后编译并跑全部用例。
-5. 结果表出现在题面上方：每个用例的判定、得分、耗时；失败的用例展开显示首处差异。
+4. 点 **提交**。插件会先保存文件、检查环境，然后编译并跑自动任务。
+5. 结果区按题型展示：Program 是用例表；Project 是 task → case/CTest 的嵌套结果，以及 Automated、Manual pending、Provisional total 汇总。
 
 ### 输入输出约定
 
@@ -151,7 +152,9 @@ WA 时通知栏会给一个**并排查看完整输出**按钮 —— 点它会�
 
 选择题在未完成时始终是问号，只用颜色区分有没有动过 —— 这样一眼就能和代码题分开。
 
-章节行右侧显示 `已通过/总数`，代码题和选择题一起计入。
+Project 的状态图标使用工具箱形状：自动判题未满时显示带色中间态；自动部分满分但存在 manual task 时显示“自动通过 · 待人工”，不会提前显示最终绿勾。
+
+章节行右侧显示 `已通过/总数`，Program、Project（只有自动部分完成且无待人工时）和 Quiz 一起计入。
 
 ### 三条关键行为
 
@@ -166,9 +169,10 @@ WA 时通知栏会给一个**并排查看完整输出**按钮 —— 点它会�
 | 内容 | 位置 |
 | --- | --- |
 | 通过状态、最好成绩、提交元数据 | VSCode `globalState` |
+| Project 最近一次自动判题摘要 | 独立的 `dsaMastery.projectProgress.v1` |
 | 每次提交的源码快照 | 插件的 `globalStorage` 目录 |
 
-两者都在 VSCode 的用户数据目录里，**不进仓库**，也不会被 `pnpm lab:clean` 删除（那条命令只清理各 Lab 的 `.lab-cache/`）。
+这些状态都在 VSCode 的用户数据目录里，**不进仓库**，也不会被 `pnpm lab:clean` 删除（那条命令只清理各 Lab 的 `.lab-cache/`）。
 
 插件使用 `01E04` 这样的稳定 Lab ID 保存进度，而不是依赖目录名。升级到采用稳定 ID 的版本时，插件会先备份旧状态，再自动迁移代码题、选择题和做题统计；既有源码快照仍能从提交历史打开，不需要手工重做题目。
 
@@ -186,7 +190,7 @@ WA 时通知栏会给一个**并排查看完整输出**按钮 —— 点它会�
 | --- | --- |
 | 提交当前题目 | 编译并评分，等同于面板上的提交按钮 |
 | 刷新题目列表 | 重新扫描 `labs/`，新增题目后用 |
-| 查看提交历史 | 列出某题的全部提交，可打开或对比 |
+| 查看提交历史 | Program 列出某题的全部提交，可打开或对比；Project 暂不支持多文件历史 |
 | 检查实验环境 | 手动运行环境检测，显示可用编译器 |
 | 重置全部做题进度 | 清空状态与快照，需二次确认 |
 
@@ -205,11 +209,13 @@ WA 时通知栏会给一个**并排查看完整输出**按钮 —— 点它会�
 | --- | --- |
 | Program | 完整支持 |
 | Quiz | 支持四选一单项选择、解析和本地进度 |
-| Project | 不显示。含人工评审 task，自动判分无法决定是否完成 |
+| Project | 支持展示、stdio/CTest 自动判题和 manual `PENDING`；不录入人工分、不提供多文件历史 |
 
 ### 插件不做的事
 
 - **交互式运行**（手工输入输出）需要真实终端，请继续用 `pnpm lab:interactive`。
+- **Project 的 manual task** 只展示 checklist 和 `PENDING`，人工评审仍由课程流程完成。
+- **Project 多文件历史** 暂未实现；插件只保存最近一次自动结果摘要，不复制多文件源码快照。
 - **选择题不接入终端 CLI**。答案在插件内本地判定，网页端与 VSCode 的答题进度目前不互相同步。
 - **作者维护命令**（`lab:new`、`lab:verify`、`lab:refresh-expected`、`lab:pack`）不在插件里，它们面向出题者而非学习者。
 - **环境问题只能诊断，不能解决**。插件会告诉你缺什么、去哪装，但编译器仍需你自己安装。

--- a/tools/vscode-extension/README.md
+++ b/tools/vscode-extension/README.md
@@ -1,6 +1,6 @@
 # DSA Mastery Labs · VSCode 扩展
 
-在 VSCode 中浏览、作答与提交 DSA Mastery 的 Program Lab 和四选一 Quiz Lab。代码题继续调用仓库判题内核，选择题在插件内本地判定。
+在 VSCode 中浏览、作答与提交 DSA Mastery 的 Program Lab、Project Lab 和四选一 Quiz Lab。代码题与项目题继续调用仓库判题内核，选择题在插件内本地判定。
 
 > **使用说明请看站内文档**：[VSCode 插件安装与使用指南](../../docs/VSCODE_EXTENSION_GUIDE.md)。
 > 本文件只面向要改这个扩展的人。
@@ -20,12 +20,12 @@ node tools/lab/cli.mjs score <lab-path> --json
 | 文件 | 职责 |
 | --- | --- |
 | `extension.ts` | 激活入口、命令注册、依赖装配 |
-| `labIndex.ts` | 扫描 `labs/chapter-*/{theory,exercise,project}/`，读 `lab.json` 与 README frontmatter，收录 `program` 与 `quiz`；迁移期兼容旧平铺目录 |
-| `cli.ts` | 判题内核适配层：spawn、解析 JSON、校验 `reportVersion`、Node 回退 |
-| `progress.ts` | 做题进度：`globalState` 索引 + `globalStorage` 源码快照 |
+| `labIndex.ts` | 扫描 `labs/chapter-*/{theory,exercise,project}/`，读取 `lab.json`、task manifest 与 README frontmatter，收录 `program`、`quiz`、`project`；迁移期兼容旧平铺目录 |
+| `cli.ts` | 判题内核适配层：spawn、解析 JSON、校验 `reportVersion`、Program/Project 结果类型与 Node 回退 |
+| `progress.ts` | 做题进度：Program/Quiz 旧状态、Project 独立摘要、`globalStorage` 源码快照 |
 | `tree.ts` | 侧边栏 TreeDataProvider（章节 → 题目） |
-| `panel.ts` | 题目面板 webview 的生命周期与提交流程 |
-| `panelHtml.ts` | 面板 HTML 渲染（题面外壳、用例区、结果表） |
+| `panel.ts` | 题目面板 webview 的生命周期、学生文件保存与提交流程 |
+| `panelHtml.ts` | 面板 HTML 渲染（题面外壳、task/case/CTest 层级、结果表） |
 | `markdown.ts` | README 渲染：切除题解、重写图片 URI、KaTeX |
 | `doctor.ts` | 环境检测与平台化安装指引 |
 
@@ -74,7 +74,7 @@ code tools/vscode-extension
 
 ```bash
 pnpm run package
-code --install-extension dsa-mastery-labs-0.1.11.vsix
+code --install-extension dsa-mastery-labs-0.1.12.vsix
 ```
 
 装完需要**完全退出 VSCode 再打开** —— 它不会热加载新装的插件。
@@ -88,6 +88,12 @@ code --install-extension dsa-mastery-labs-0.1.11.vsix
 独立 package，不加入仓库的 pnpm workspace。根目录的 `pnpm install`、`pnpm test`、`pnpm lint`、`pnpm typecheck` 与 CI 都不受影响。
 
 `dist/`、`node_modules/`、`*.vsix` 均不进版本控制。站点构建通过 `.vitepress/config.ts` 的 `srcExclude: ["tools/**"]` 排除本目录，所以这份 README 不会变成网页。
+
+### Project Lab 的实现边界
+
+Project 面板会按 task 展示依赖、权重、学生文件、stdio 公开 case、CTest 名称和 manual checklist。提交时只保存当前 Project 下已打开且属于 `student/` 的 dirty 文件，然后调用同一个 `node tools/lab/cli.mjs score <project-path> --json`。
+
+`manual` task 固定显示为 `PENDING`，自动部分满分时状态是“自动通过 · 待人工”，不是最终完成。Project 目前只保存最近一次自动判题摘要，不生成多文件提交历史和逐文件 diff；Program 的提交历史保持原行为。
 
 ## 版本耦合
 

--- a/tools/vscode-extension/media/panel.css
+++ b/tools/vscode-extension/media/panel.css
@@ -1839,3 +1839,374 @@ body.program-body {
     transition: none;
   }
 }
+
+/* ===== Project 工作台 ===== */
+
+body.project-body {
+  height: 100vh;
+  min-height: 100vh;
+  margin: 0;
+  padding: 0 24px;
+  overflow: hidden;
+}
+
+.project-page {
+  --lab-actionbar-reserve: 128px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  padding-bottom: var(--lab-actionbar-reserve);
+}
+
+.project-scroll-region {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-bottom: 16px;
+  scrollbar-gutter: stable;
+}
+
+.project-page .lab-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(260px, min(38%, 420px));
+  gap: 20px;
+  align-items: start;
+  min-width: 0;
+}
+
+.project-page .lab-workspace.is-inspector-collapsed {
+  grid-template-columns: minmax(0, 1fr) 44px;
+}
+
+.project-page .lab-reading-surface,
+.project-page .lab-inspector {
+  min-width: 0;
+  border: 1px solid var(--dsa-border);
+  border-radius: var(--dsa-radius);
+  background: var(--dsa-surface);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+}
+
+.project-page .lab-reading-surface {
+  padding: clamp(20px, 3vw, 32px);
+}
+
+.project-page .readme {
+  max-width: 76ch;
+  margin: 0;
+}
+
+.project-task-overview {
+  margin-top: 34px;
+  padding-top: 24px;
+  border-top: 1px solid var(--dsa-border);
+}
+
+.project-section-heading {
+  margin-bottom: 14px;
+}
+
+.project-eyebrow {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--dsa-muted);
+  font-family: var(--vscode-editor-font-family);
+  font-size: 0.7em;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.project-section-heading h2 {
+  margin: 0;
+  font-size: 1.1em;
+  line-height: 1.35;
+}
+
+.project-task-card {
+  min-width: 0;
+  margin-top: 12px;
+  padding: 16px;
+  border: 1px solid var(--dsa-border);
+  border-radius: 9px;
+  background: var(--dsa-surface-raised);
+}
+
+.project-task-header,
+.project-task-result-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.project-task-header strong {
+  flex: none;
+  color: var(--dsa-accent);
+  font-family: var(--vscode-editor-font-family);
+  font-size: 0.86em;
+  font-weight: 650;
+}
+
+.project-task-id {
+  font-family: var(--vscode-editor-font-family);
+  font-size: 0.92em;
+  font-weight: 650;
+}
+
+.project-task-kind {
+  margin-left: 9px;
+  color: var(--dsa-muted);
+  font-size: 0.78em;
+}
+
+.project-task-meta {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  gap: 8px 14px;
+  margin: 12px 0 14px;
+  color: var(--dsa-muted);
+  font-size: 0.78em;
+}
+
+.project-task-meta div {
+  min-width: 0;
+}
+
+.project-task-meta dt {
+  margin-bottom: 2px;
+  font-size: 0.84em;
+}
+
+.project-task-meta dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.project-task-files,
+.project-task-cases,
+.project-task-tests,
+.project-manual {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--dsa-border);
+}
+
+.project-task-card h4 {
+  margin: 0 0 8px;
+  color: var(--dsa-muted);
+  font-size: 0.78em;
+  font-weight: 650;
+}
+
+.project-file-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-width: 0;
+  margin-top: 6px;
+  padding: 7px 9px;
+  border-color: var(--dsa-border);
+  background: var(--dsa-surface);
+  color: var(--dsa-text);
+  text-align: left;
+}
+
+.project-file-button code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--dsa-accent);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-file-button span {
+  flex: none;
+  margin-left: 10px;
+  color: var(--dsa-muted);
+  font-size: 0.82em;
+}
+
+.project-file-button:hover {
+  border-color: var(--dsa-border-strong);
+  background: var(--dsa-accent-soft);
+}
+
+.project-case {
+  margin-top: 7px;
+}
+
+.project-case summary {
+  padding: 8px 0;
+}
+
+.project-case .io {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.project-case h5 {
+  margin: 0 0 5px;
+  color: var(--dsa-muted);
+  font-size: 0.78em;
+  font-weight: 650;
+}
+
+.project-test-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.project-test-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  max-width: 100%;
+  padding: 5px 8px;
+  border: 1px solid var(--dsa-border);
+  border-radius: 6px;
+  background: var(--dsa-surface);
+  color: var(--dsa-muted);
+  font-size: 0.78em;
+}
+
+.project-test-chip code {
+  overflow: hidden;
+  color: var(--dsa-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-manual {
+  color: var(--dsa-muted);
+  font-size: 0.82em;
+}
+
+.project-manual ul,
+.project-result-checklist {
+  margin: 8px 0 0;
+  padding-left: 20px;
+}
+
+.project-pending {
+  color: var(--dsa-warning);
+  font-weight: 650;
+}
+
+.project-empty {
+  margin: 0;
+  color: var(--dsa-muted);
+  font-size: 0.82em;
+}
+
+.project-page .summary.pending {
+  border-left: 3px solid var(--dsa-warning);
+  background: color-mix(in srgb, var(--dsa-warning) 8%, var(--dsa-surface));
+}
+
+.project-page .summary.pending h3 {
+  color: var(--dsa-warning);
+}
+
+.project-score-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.project-score-grid span {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--dsa-border);
+  border-radius: 6px;
+  background: var(--dsa-surface-muted);
+  font-family: var(--vscode-editor-font-family);
+  font-size: 0.8em;
+}
+
+.project-score-grid strong {
+  color: var(--dsa-muted);
+  font-family: var(--vscode-font-family);
+  font-size: 0.82em;
+  font-weight: 600;
+}
+
+.project-task-result {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--dsa-border);
+}
+
+.project-task-result-heading {
+  color: var(--dsa-muted);
+  font-size: 0.82em;
+}
+
+.project-task-result-heading code {
+  color: var(--dsa-text);
+  font-weight: 650;
+}
+
+.project-result-table {
+  margin-top: 9px;
+}
+
+.project-diagnostic {
+  margin: 9px 0 0;
+  max-height: 260px;
+  overflow: auto;
+}
+
+.project-build-status {
+  margin: 9px 0 0;
+  color: var(--dsa-danger);
+  font-size: 0.82em;
+}
+
+.project-result-checklist {
+  color: var(--dsa-muted);
+  font-size: 0.82em;
+}
+
+@media (max-width: 720px) {
+  .project-page {
+    --lab-actionbar-reserve: 144px;
+  }
+
+  .project-page .lab-workspace,
+  .project-page .lab-workspace.is-inspector-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .project-page .lab-inspector {
+    position: static;
+    width: 100%;
+  }
+}
+
+@media (max-width: 460px) {
+  .project-page {
+    --lab-actionbar-reserve: 236px;
+  }
+
+  .project-page .lab-reading-surface {
+    padding: 18px 16px;
+  }
+
+  .project-task-meta,
+  .project-score-grid,
+  .project-case .io {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/tools/vscode-extension/package.json
+++ b/tools/vscode-extension/package.json
@@ -1,8 +1,8 @@
 {
   "name": "dsa-mastery-labs",
   "displayName": "DSA Mastery Labs",
-  "description": "在 VSCode 中浏览、作答与提交 DSA Mastery 的 C++ 代码题",
-  "version": "0.1.11",
+  "description": "在 VSCode 中浏览、作答与提交 DSA Mastery 的代码题、项目题与选择题",
+  "version": "0.1.12",
   "private": true,
   "publisher": "dsa-mastery",
   "license": "SEE LICENSE IN ../../README.md",
@@ -32,8 +32,8 @@
       "dsaMastery": [
         {
           "id": "dsaMastery.labs",
-          "name": "代码题",
-          "contextualTitle": "DSA Mastery 代码题"
+          "name": "题目",
+          "contextualTitle": "DSA Mastery 题目"
         }
       ]
     },
@@ -100,7 +100,7 @@
       "view/item/context": [
         {
           "command": "dsaMastery.submit",
-          "when": "view == dsaMastery.labs && viewItem == dsaMasteryLab",
+          "when": "view == dsaMastery.labs && (viewItem == dsaMasteryLab || viewItem == dsaMasteryProject)",
           "group": "inline"
         },
         {

--- a/tools/vscode-extension/src/cli.ts
+++ b/tools/vscode-extension/src/cli.ts
@@ -10,6 +10,7 @@ const SUPPORTED_REPORT_VERSION = 1;
 export const EXIT = { OK: 0, SCORE_NOT_FULL: 1, TOOL_ERROR: 2 } as const;
 
 export type Verdict = "AC" | "WA" | "TLE" | "RE" | "CE" | "OLE" | "IE";
+export type ProjectStatus = Verdict | "PENDING";
 
 export interface CaseResult {
   id: string;
@@ -45,6 +46,69 @@ export interface ScoreResult {
     stdout: string;
     stderr: string;
   };
+}
+
+export interface ProjectCtestResult {
+  name: string;
+  verdict: Verdict;
+  points: number;
+  maxPoints: number;
+  durationMs: number;
+  output: string;
+}
+
+export interface ProjectBuildResult {
+  ok: boolean;
+  phase: "configure" | "build";
+  target: "student" | "solution";
+  configure?: unknown;
+  build?: unknown;
+}
+
+interface ProjectTaskResultBase {
+  id: string;
+  kind: "stdio" | "ctest" | "manual";
+  status: ProjectStatus;
+  weight: number;
+  weightedScore: number;
+}
+
+export interface ProjectStdioTaskResult extends ProjectTaskResultBase {
+  kind: "stdio";
+  status: Verdict;
+  score: number;
+  maxScore: number;
+  judge: ScoreResult;
+}
+
+export interface ProjectCtestTaskResult extends ProjectTaskResultBase {
+  kind: "ctest";
+  status: Verdict;
+  score: number;
+  maxScore: number;
+  tests: ProjectCtestResult[];
+  build?: ProjectBuildResult;
+}
+
+export interface ProjectManualTaskResult extends ProjectTaskResultBase {
+  kind: "manual";
+  status: "PENDING";
+  weightedScore: 0;
+  checklist: string[];
+}
+
+export type ProjectTaskResult = ProjectStdioTaskResult | ProjectCtestTaskResult | ProjectManualTaskResult;
+
+export interface ProjectScoreResult {
+  target: "student" | "solution";
+  tasks: ProjectTaskResult[];
+  automatedScore: number;
+  automatedMax: number;
+  manualPending: number;
+  provisionalTotal: number;
+  total: number;
+  automatedFull: boolean;
+  internalError: boolean;
 }
 
 export interface DoctorTool {
@@ -197,6 +261,20 @@ export async function scoreLab(repoRoot: string, labRelativePath: string): Promi
   const { report, exitCode } = await runCli<ScoreResult>(repoRoot, ["score", labRelativePath]);
   if (!report.result) {
     throw new CliError(`判题报告缺少 result 字段（退出码 ${exitCode}）。`, "REPORT_INCOMPLETE");
+  }
+  return report.result;
+}
+
+/**
+ * 对 Project Lab 评分。
+ *
+ * Project 的权重、CMake/CTest 结果和 stdio 嵌套用例都由 lab CLI 计算；扩展只接收并展示
+ * 原始聚合结果，不在这里重新实现一套评分规则。
+ */
+export async function scoreProject(repoRoot: string, labRelativePath: string): Promise<ProjectScoreResult> {
+  const { report, exitCode } = await runCli<ProjectScoreResult>(repoRoot, ["score", labRelativePath]);
+  if (!report.result) {
+    throw new CliError(`Project 判题报告缺少 result 字段（退出码 ${exitCode}）。`, "REPORT_INCOMPLETE");
   }
   return report.result;
 }

--- a/tools/vscode-extension/src/doctor.ts
+++ b/tools/vscode-extension/src/doctor.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import * as vscode from "vscode";
 import { CliError, runDoctor, type DoctorResult } from "./cli";
-import type { ProgramLab } from "./labIndex";
+import type { LabEntry } from "./labIndex";
 
 /** 仓库内已有的环境准备指南，按平台选择。 */
 function setupGuide(platform: string): { label: string; relativePath: string } {
@@ -46,7 +46,7 @@ export class EnvironmentGuard {
 
   constructor(private readonly repoRoot: string) {}
 
-  async ensureReady(lab: ProgramLab): Promise<boolean> {
+  async ensureReady(lab: LabEntry): Promise<boolean> {
     if (this.verified) return true;
 
     let environment: DoctorResult;
@@ -71,7 +71,7 @@ export class EnvironmentGuard {
   }
 
   /** 手动重跑检查，并把完整结果显示出来。 */
-  async inspect(lab: ProgramLab): Promise<void> {
+  async inspect(lab: LabEntry): Promise<void> {
     const environment = await runDoctor(this.repoRoot, lab.relativePath);
     this.verified = environment.ok;
 

--- a/tools/vscode-extension/src/extension.ts
+++ b/tools/vscode-extension/src/extension.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import * as vscode from "vscode";
 import { CliError } from "./cli";
 import { EnvironmentGuard } from "./doctor";
-import type { ProgramLab } from "./labIndex";
+import type { LabEntry } from "./labIndex";
 import { LabPanel } from "./panel";
 import { ProgressTracker, type HistoryEntry } from "./progress";
 import { StatsPanel } from "./statsPanel";
@@ -52,7 +52,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   };
 
   /** 解析命令参数：可能是树节点、lab 名，或什么都没有（用当前面板/当前文件）。 */
-  const resolveLab = async (argument?: unknown): Promise<ProgramLab | undefined> => {
+  const resolveLab = async (argument?: unknown): Promise<LabEntry | undefined> => {
     if (typeof argument === "string") return tree.findLab(argument);
 
     const node = argument as TreeNode | undefined;
@@ -64,14 +64,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // 退化到当前编辑器所在的 lab。
     const file = vscode.window.activeTextEditor?.document.fileName;
     if (!file) return undefined;
-    return tree.allLabs().find((lab) => file.startsWith(lab.labPath + path.sep));
+    return tree.allLabs().find((lab) => isWithinDirectory(lab.labPath, file));
   };
 
   context.subscriptions.push(
     vscode.commands.registerCommand("dsaMastery.openLab", async (argument?: unknown) => {
       const lab = await resolveLab(argument);
       if (!lab) {
-        await vscode.window.showWarningMessage("没有找到对应的代码题。请在题目列表中选择一道题。");
+        await vscode.window.showWarningMessage("没有找到对应的题目。请在题目列表中选择一道题。");
         return;
       }
       await LabPanel.show(lab, panelDeps);
@@ -80,7 +80,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand("dsaMastery.submit", async (argument?: unknown) => {
       const lab = await resolveLab(argument);
       if (!lab) {
-        await vscode.window.showWarningMessage("没有可提交的题目。请先打开一道代码题。");
+        await vscode.window.showWarningMessage("没有可提交的题目。请先打开一道题。");
         return;
       }
       // 统一走面板提交，保证结果有地方显示。
@@ -106,7 +106,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand("dsaMastery.runDoctor", async (argument?: unknown) => {
       const lab = (await resolveLab(argument)) ?? tree.allLabs()[0];
       if (!lab) {
-        await vscode.window.showWarningMessage("没有找到可用于环境检测的代码题。");
+        await vscode.window.showWarningMessage("没有找到可用于环境检测的题目。");
         return;
       }
       try {
@@ -134,7 +134,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 }
 
 /** 列出某题的提交历史，可打开任一次提交的源码快照，或与当前代码对比。 */
-async function showHistory(lab: ProgramLab, progress: ProgressTracker): Promise<void> {
+async function showHistory(lab: LabEntry, progress: ProgressTracker): Promise<void> {
+  if (lab.type !== "program") {
+    await vscode.window.showInformationMessage(
+      lab.type === "project"
+        ? "Project 暂不支持多文件提交历史；当前仅保留最近一次自动判题摘要。"
+        : "选择题没有代码提交历史。",
+    );
+    return;
+  }
   const state = progress.get(lab.id);
   if (!state || state.history.length === 0) {
     await vscode.window.showInformationMessage(`${lab.title} 还没有提交记录。`);
@@ -182,4 +190,9 @@ async function showHistory(lab: ProgramLab, progress: ProgressTracker): Promise<
 
 export function deactivate(): void {
   // 状态在每次提交时已落盘，无需在此处理。
+}
+
+function isWithinDirectory(root: string, target: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  return relative !== "" && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
 }

--- a/tools/vscode-extension/src/labIndex.ts
+++ b/tools/vscode-extension/src/labIndex.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir } from "node:fs/promises";
+import { lstat, readFile, readdir, realpath } from "node:fs/promises";
 import path from "node:path";
 import matter from "gray-matter";
 import { parseQuizQuestions, type QuizQuestion } from "./quiz";
@@ -7,17 +7,15 @@ import { readStableLabId } from "./labIdentity";
 /**
  * 一道可作答 lab 的静态信息，来自 lab.json 与 README frontmatter。
  *
- * 名字沿用 ProgramLab 是历史原因（最初只支持 program），现在同时承载 quiz。
- * type 决定走哪条判定路径：program 调判题内核，quiz 在扩展内比对选项。
+ * 共享字段独立出来，避免把 project 伪装成只有一个 student/main.cpp 的 program。
  */
-export interface ProgramLab {
+interface LabBase {
   /** 稳定题号，例如 13E01。发布后不随目录或展示顺序改变，用作状态主键。 */
   id: string;
   /** 当前 lab 目录名，例如 E-13-01-container-with-most-water。 */
   name: string;
   /** 迁移前的目录名，仅用于把本机旧进度键转换为稳定 labId。 */
   legacyNames: string[];
-  type: "program" | "quiz";
   /** lab 目录绝对路径。 */
   labPath: string;
   /** 相对仓库根的路径，用于展示与传给 CLI。 */
@@ -30,17 +28,63 @@ export interface ProgramLab {
   difficulty?: string;
   duration?: string;
   status?: string;
+}
+
+export interface ProgramLab extends LabBase {
+  type: "program";
   /** student 目标的源文件相对路径，当前全部为单文件 student/main.cpp。 */
   studentSources: string[];
   /** judge.cases 声明的用例清单路径，通常是 tests/cases.json。 */
   casesFile: string;
-  quizQuestions?: QuizQuestion[];
 }
+
+export interface QuizLab extends LabBase {
+  type: "quiz";
+  quizQuestions: QuizQuestion[];
+}
+
+export type ProjectTaskKind = "stdio" | "ctest" | "manual";
+
+export interface ProjectCtestTest {
+  name: string;
+  points: number;
+}
+
+export interface ProjectTask {
+  id: string;
+  /** 相对 Project 根目录的 task 路径，例如 tasks/task-01-matcher。 */
+  relativePath: string;
+  weight: number;
+  kind: ProjectTaskKind;
+  dependsOn: string[];
+  /** stdio task 的 targets.student.sources；其它 task 为空。 */
+  studentSources: string[];
+  cases?: LoadedTestCase[];
+  ctestTests?: ProjectCtestTest[];
+  checklist?: string[];
+}
+
+export interface ProjectStudentFile {
+  taskId: string;
+  /** 相对 Project 根目录的文件路径，用于 UI 展示和安全匹配。 */
+  relativePath: string;
+  /** 文件绝对路径，用于打开和保存。 */
+  absolutePath: string;
+}
+
+export interface ProjectLab extends LabBase {
+  type: "project";
+  buildSystem: "cmake";
+  tasks: ProjectTask[];
+  studentFiles: ProjectStudentFile[];
+}
+
+export type LabEntry = ProgramLab | QuizLab | ProjectLab;
 
 export interface Chapter {
   chapter: number;
   chapterTitle: string;
-  labs: ProgramLab[];
+  labs: LabEntry[];
 }
 
 /** tests/cases.json 中的一个公开用例。schema 中没有 hidden 字段，全部用例均可展示。 */
@@ -53,6 +97,8 @@ export interface TestCase {
   timeMs?: number;
   outputKb?: number;
 }
+
+export type LoadedTestCase = TestCase & { inputText: string; expectedText: string };
 
 async function readJson<T>(file: string): Promise<T> {
   return JSON.parse(await readFile(file, "utf8")) as T;
@@ -70,17 +116,17 @@ function parseChapterNumber(source: unknown, fallbackDir: string): number {
 }
 
 /**
- * 扫描 labs/ 下全部 lab，返回 type 为 "program" 或 "quiz" 的题目。
+ * 扫描 labs/ 下全部 lab，返回 program、quiz 和 project 题目。
  *
  * program 走判题内核（编译 + 跑用例），quiz 完全在扩展内判定（读 quiz.json、
- * 比对选项），不需要编译器也不调用 CLI。
+ * 比对选项），不需要编译器也不调用 CLI；project 由判题内核处理 stdio/CTest，
+ * manual task 在扩展中只展示为待人工状态。
  *
- * project 含人工评审 task，自动判分无法决定是否完成，因此在这里过滤掉。
  * 只有 README 而没有 lab.json 的目录同样跳过 —— 它们不可运行。
  */
 export async function discoverProgramLabs(repoRoot: string): Promise<Chapter[]> {
   const labsRoot = path.join(repoRoot, "labs");
-  const labs: ProgramLab[] = [];
+  const labs: LabEntry[] = [];
   const categories = ["theory", "exercise", "project"] as const;
   const categoryNames = new Set<string>(categories);
 
@@ -137,20 +183,16 @@ async function loadProgramLab(
   labPath: string,
   labDir: string,
   chapterDir: string,
-): Promise<ProgramLab | undefined> {
-  let manifest: {
-    type?: string;
-    quiz?: { questions?: string };
-    targets?: { student?: { sources?: string[] } };
-    judge?: { cases?: string };
-  };
+): Promise<LabEntry | undefined> {
+  let manifest: RawLabManifest;
   try {
     manifest = await readJson(path.join(labPath, "lab.json"));
   } catch {
     // 没有 lab.json（或无法解析）的目录不可运行，直接跳过。
     return undefined;
   }
-  if (manifest.type !== "program" && manifest.type !== "quiz") return undefined;
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return undefined;
+  if (manifest.type !== "program" && manifest.type !== "quiz" && manifest.type !== "project") return undefined;
 
   let front: Record<string, unknown> = {};
   try {
@@ -165,8 +207,6 @@ async function loadProgramLab(
       const questions = parseQuizQuestions(await readJson<unknown>(path.join(labPath, quizFile)));
       return buildLab(repoRoot, labPath, labDir, chapterDir, front, {
         type: "quiz",
-        studentSources: [],
-        casesFile: "",
         quizQuestions: questions,
       });
     } catch {
@@ -174,14 +214,233 @@ async function loadProgramLab(
     }
   }
 
-  const sources = manifest.targets?.student?.sources ?? [];
-  if (sources.length === 0) return undefined;
+  if (manifest.type === "program") {
+    const sources = stringArray(manifest.targets?.student?.sources) ?? [];
+    if (sources.length === 0) return undefined;
+    return buildLab(repoRoot, labPath, labDir, chapterDir, front, {
+      type: "program",
+      studentSources: sources,
+      casesFile: manifest.judge?.cases ?? "tests/cases.json",
+    });
+  }
 
-  return buildLab(repoRoot, labPath, labDir, chapterDir, front, {
-    type: "program",
-    studentSources: sources,
-    casesFile: manifest.judge?.cases ?? "tests/cases.json",
-  });
+  return loadProjectLab(repoRoot, labPath, labDir, chapterDir, front, manifest);
+}
+
+interface RawLabManifest {
+  schemaVersion?: unknown;
+  type?: string;
+  language?: unknown;
+  toolchain?: { standard?: unknown };
+  quiz?: { questions?: string };
+  targets?: { student?: { sources?: unknown } };
+  judge?: { cases?: string };
+  buildSystem?: string;
+  tasks?: unknown;
+}
+
+interface RawProjectTaskEntry {
+  id?: unknown;
+  path?: unknown;
+  weight?: unknown;
+  kind?: unknown;
+  dependsOn?: unknown;
+}
+
+interface RawTaskManifest {
+  schemaVersion?: unknown;
+  kind?: unknown;
+  targets?: { student?: { sources?: unknown } };
+  judge?: { kind?: unknown; cases?: unknown };
+  ctest?: { tests?: unknown };
+  checklist?: unknown;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) return undefined;
+  return value;
+}
+
+function isSafeRelativePath(value: string): boolean {
+  if (!value || path.isAbsolute(value)) return false;
+  const normalized = path.normalize(value);
+  return normalized !== ".." && !normalized.startsWith(`..${path.sep}`) && normalized !== ".";
+}
+
+async function isWithinRealDirectory(root: string, candidate: string): Promise<boolean> {
+  try {
+    const [realRoot, realCandidate] = await Promise.all([realpath(root), realpath(candidate)]);
+    const relative = path.relative(realRoot, realCandidate);
+    return relative !== "" && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+  } catch {
+    return false;
+  }
+}
+
+async function collectRegularFiles(root: string, current = root): Promise<string[]> {
+  try {
+    // lstat 先检查根目录本身，避免 student/ 目录是符号链接时 readdir 跟到 Project 外。
+    if (!(await lstat(current)).isDirectory()) return [];
+  } catch {
+    return [];
+  }
+
+  let entries;
+  try {
+    entries = await readdir(current, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const absolutePath = path.join(current, entry.name);
+    // Dirent 对符号链接不会报告为 directory/file，因而不会跟随它们越出 Project 根目录。
+    if (entry.isDirectory()) {
+      files.push(...await collectRegularFiles(root, absolutePath));
+    } else if (entry.isFile()) {
+      files.push(absolutePath);
+    }
+  }
+  return files;
+}
+
+async function loadProjectLab(
+  repoRoot: string,
+  labPath: string,
+  labDir: string,
+  chapterDir: string,
+  front: Record<string, unknown>,
+  manifest: RawLabManifest,
+): Promise<ProjectLab | undefined> {
+  const toolchain = manifest.toolchain;
+  if (
+    manifest.schemaVersion !== 1 ||
+    manifest.language !== "cpp" ||
+    !toolchain ||
+    typeof toolchain !== "object" ||
+    Array.isArray(toolchain) ||
+    (toolchain.standard !== "c++17" && toolchain.standard !== "c++20") ||
+    manifest.buildSystem !== "cmake" ||
+    !Array.isArray(manifest.tasks) ||
+    manifest.tasks.length === 0
+  ) return undefined;
+
+  const tasks: ProjectTask[] = [];
+  const studentFiles: ProjectStudentFile[] = [];
+  const taskIds = new Set<string>();
+  let totalWeight = 0;
+  for (const candidate of manifest.tasks) {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return undefined;
+    const rawEntry = candidate as RawProjectTaskEntry;
+    const id = typeof rawEntry.id === "string" ? rawEntry.id : "";
+    const relativePath = typeof rawEntry.path === "string" ? rawEntry.path : "";
+    const weight = typeof rawEntry.weight === "number" ? rawEntry.weight : NaN;
+    const kind = rawEntry.kind;
+    if (!/^[a-z][a-z0-9-]*$/.test(id) || taskIds.has(id) || !isSafeRelativePath(relativePath) || !Number.isInteger(weight) || weight < 1 || weight > 100) return undefined;
+    if (kind !== "stdio" && kind !== "ctest" && kind !== "manual") return undefined;
+    taskIds.add(id);
+    totalWeight += weight;
+
+    let taskManifest: RawTaskManifest;
+    try {
+      taskManifest = await readJson<RawTaskManifest>(path.join(labPath, relativePath, "task.json"));
+    } catch {
+      return undefined;
+    }
+    if (
+      !taskManifest ||
+      typeof taskManifest !== "object" ||
+      Array.isArray(taskManifest) ||
+      taskManifest.schemaVersion !== 1 ||
+      taskManifest.kind !== kind
+    ) return undefined;
+
+    const taskPath = path.join(labPath, relativePath);
+    // 文本路径安全不等于真实路径安全：task 目录本身也不能是越出 Project 的链接。
+    if (!(await isWithinRealDirectory(labPath, taskPath))) return undefined;
+    const taskStudentRoot = path.join(taskPath, "student");
+    const taskStudentAbsoluteFiles = await collectRegularFiles(taskStudentRoot);
+    for (const absolutePath of taskStudentAbsoluteFiles) {
+      studentFiles.push({
+        taskId: id,
+        relativePath: path.relative(labPath, absolutePath).split(path.sep).join("/"),
+        absolutePath,
+      });
+    }
+
+    const dependsOn = rawEntry.dependsOn === undefined ? [] : stringArray(rawEntry.dependsOn);
+    if (!dependsOn || new Set(dependsOn).size !== dependsOn.length) return undefined;
+    let studentSources: string[] = [];
+    const projectTask: ProjectTask = { id, relativePath: relativePath.split(path.sep).join("/"), weight, kind, dependsOn, studentSources };
+
+    if (kind === "stdio") {
+      studentSources = stringArray(taskManifest.targets?.student?.sources) ?? [];
+      const casesFile = taskManifest.judge?.cases;
+      if (
+        taskManifest.judge?.kind !== "stdio" ||
+        typeof casesFile !== "string" ||
+        studentSources.length === 0 ||
+        !studentSources.every(isSafeRelativePath) ||
+        !isSafeRelativePath(casesFile)
+      ) return undefined;
+      projectTask.studentSources = studentSources;
+      projectTask.cases = await loadTestCasesAt(taskPath, casesFile);
+    } else if (kind === "ctest") {
+      const rawTests = taskManifest.ctest?.tests;
+      if (!Array.isArray(rawTests) || rawTests.length === 0) return undefined;
+      const ctestTests: ProjectCtestTest[] = [];
+      for (const rawTest of rawTests) {
+        if (!rawTest || typeof rawTest !== "object" || Array.isArray(rawTest)) return undefined;
+        const test = rawTest as { name?: unknown; points?: unknown };
+        if (
+          typeof test.name !== "string" ||
+          test.name.trim().length === 0 ||
+          typeof test.points !== "number" ||
+          !Number.isInteger(test.points) ||
+          test.points < 1 ||
+          ctestTests.some((existing) => existing.name === test.name)
+        ) return undefined;
+        ctestTests.push({ name: test.name, points: test.points });
+      }
+      if (ctestTests.reduce((sum, test) => sum + test.points, 0) !== 100) return undefined;
+      projectTask.ctestTests = ctestTests;
+    } else {
+      const checklist = stringArray(taskManifest.checklist);
+      if (!checklist || checklist.length === 0 || checklist.some((item) => item.trim().length === 0)) return undefined;
+      projectTask.checklist = checklist;
+    }
+
+    tasks.push(projectTask);
+  }
+
+  if (totalWeight !== 100) return undefined;
+  for (const task of tasks) {
+    if (task.dependsOn.some((dependency) => !taskIds.has(dependency) || dependency === task.id)) return undefined;
+  }
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const byId = new Map(tasks.map((task) => [task.id, task]));
+  const hasCycle = (id: string): boolean => {
+    if (visiting.has(id)) return true;
+    if (visited.has(id)) return false;
+    visiting.add(id);
+    for (const dependency of byId.get(id)?.dependsOn ?? []) {
+      if (hasCycle(dependency)) return true;
+    }
+    visiting.delete(id);
+    visited.add(id);
+    return false;
+  };
+  if (tasks.some((task) => hasCycle(task.id))) return undefined;
+
+  return {
+    ...buildBase(repoRoot, labPath, labDir, chapterDir, front),
+    type: "project",
+    buildSystem: "cmake",
+    tasks,
+    studentFiles: studentFiles.sort((left, right) => left.relativePath.localeCompare(right.relativePath)),
+  };
 }
 
 function buildLab(
@@ -190,8 +449,18 @@ function buildLab(
   labDir: string,
   chapterDir: string,
   front: Record<string, unknown>,
-  details: Pick<ProgramLab, "type" | "studentSources" | "casesFile" | "quizQuestions">,
-): ProgramLab {
+  details: { type: "program"; studentSources: string[]; casesFile: string } | { type: "quiz"; quizQuestions: QuizQuestion[] },
+): ProgramLab | QuizLab {
+  return { ...buildBase(repoRoot, labPath, labDir, chapterDir, front), ...details };
+}
+
+function buildBase(
+  repoRoot: string,
+  labPath: string,
+  labDir: string,
+  chapterDir: string,
+  front: Record<string, unknown>,
+): LabBase {
   const order = typeof front.order === "number" ? front.order : Number.MAX_SAFE_INTEGER;
   const chapter = parseChapterNumber(front.chapter, chapterDir);
   const slug = labDir.match(/^[TEP]-\d{2}-\d{2,}-(.+)$/)?.[1];
@@ -203,7 +472,6 @@ function buildLab(
     id: readStableLabId(front.labId, labDir),
     name: labDir,
     legacyNames,
-    type: details.type,
     labPath,
     relativePath: path.relative(repoRoot, labPath).split(path.sep).join("/"),
     title: typeof front.title === "string" ? front.title : labDir,
@@ -214,28 +482,32 @@ function buildLab(
     difficulty: typeof front.difficulty === "string" ? front.difficulty : undefined,
     duration: typeof front.duration === "string" ? front.duration : undefined,
     status: typeof front.status === "string" ? front.status : undefined,
-    studentSources: details.studentSources,
-    casesFile: details.casesFile,
-    quizQuestions: details.quizQuestions,
   };
 }
 
 /** 读取公开用例，并把每个用例的输入与期望输出一并载入，供题目面板展示。 */
 export async function loadTestCases(
   lab: ProgramLab,
-): Promise<Array<TestCase & { inputText: string; expectedText: string }>> {
+): Promise<LoadedTestCase[]> {
+  return loadTestCasesAt(lab.labPath, lab.casesFile);
+}
+
+async function loadTestCasesAt(root: string, casesFile: string): Promise<LoadedTestCase[]> {
+  if (!isSafeRelativePath(casesFile)) return [];
   let cases: TestCase[];
   try {
-    cases = await readJson<TestCase[]>(path.join(lab.labPath, lab.casesFile));
+    cases = await readJson<TestCase[]>(path.join(root, casesFile));
   } catch {
     return [];
   }
 
-  const loaded = [];
+  if (!Array.isArray(cases)) return [];
+  const loaded: LoadedTestCase[] = [];
   for (const testCase of cases) {
+    if (!testCase || typeof testCase.id !== "string" || typeof testCase.input !== "string" || typeof testCase.expected !== "string") continue;
     const [inputText, expectedText] = await Promise.all([
-      readFile(path.join(lab.labPath, testCase.input), "utf8").catch(() => ""),
-      readFile(path.join(lab.labPath, testCase.expected), "utf8").catch(() => ""),
+      isSafeRelativePath(testCase.input) ? readFile(path.join(root, testCase.input), "utf8").catch(() => "") : Promise.resolve(""),
+      isSafeRelativePath(testCase.expected) ? readFile(path.join(root, testCase.expected), "utf8").catch(() => "") : Promise.resolve(""),
     ]);
     loaded.push({ ...testCase, inputText, expectedText });
   }

--- a/tools/vscode-extension/src/markdown.ts
+++ b/tools/vscode-extension/src/markdown.ts
@@ -4,7 +4,7 @@ import matter from "gray-matter";
 import MarkdownIt from "markdown-it";
 import katex from "katex";
 import * as vscode from "vscode";
-import type { ProgramLab } from "./labIndex";
+import type { LabEntry } from "./labIndex";
 
 /**
  * 需要从题面中移除的小节标题。
@@ -75,7 +75,7 @@ function renderMath(md: MarkdownIt): void {
 }
 
 /** 把 README 里的相对图片路径改写为 webview 可加载的 URI。 */
-function rewriteImages(md: MarkdownIt, lab: ProgramLab, webview: vscode.Webview): void {
+function rewriteImages(md: MarkdownIt, lab: LabEntry, webview: vscode.Webview): void {
   const original = md.renderer.rules.image;
   md.renderer.rules.image = (tokens, index, options, env, self) => {
     const token = tokens[index];
@@ -98,7 +98,7 @@ export interface RenderedReadme {
 /** 渲染 Quiz 的题干、选项和解析片段，沿用题面 Markdown、图片与 KaTeX 规则。 */
 export function renderMarkdownFragment(
   source: string,
-  lab: ProgramLab,
+  lab: LabEntry,
   webview: vscode.Webview,
   allowHtml = false,
 ): string {
@@ -110,7 +110,7 @@ export function renderMarkdownFragment(
 
 /** 读取并渲染题面：去掉 frontmatter 与题解，处理图片与公式。 */
 export async function renderReadme(
-  lab: ProgramLab,
+  lab: LabEntry,
   webview: vscode.Webview,
 ): Promise<RenderedReadme> {
   let raw = "";

--- a/tools/vscode-extension/src/panel.ts
+++ b/tools/vscode-extension/src/panel.ts
@@ -2,12 +2,12 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import * as vscode from "vscode";
-import { CliError, scoreLab, type ScoreResult } from "./cli";
+import { CliError, scoreLab, scoreProject, type ProjectScoreResult, type ScoreResult } from "./cli";
 import type { EnvironmentGuard } from "./doctor";
-import { loadTestCases, studentSourcePath, type ProgramLab } from "./labIndex";
+import { loadTestCases, studentSourcePath, type LabEntry, type ProjectLab } from "./labIndex";
 import { renderMarkdownFragment, renderReadme } from "./markdown";
 import type { ProgressTracker } from "./progress";
-import { renderPanelHtml, renderQuizFeedbackHtml, renderQuizPanelHtml, renderResultHtml, type PanelNav, type QuizQuestionView } from "./panelHtml";
+import { renderPanelHtml, renderProjectPanelHtml, renderProjectResultHtml, renderQuizFeedbackHtml, renderQuizPanelHtml, renderResultHtml, type PanelNav, type QuizQuestionView } from "./panelHtml";
 
 type LoadedCase = Awaited<ReturnType<typeof loadTestCases>>[number];
 
@@ -18,7 +18,7 @@ interface PanelDeps {
   guard: EnvironmentGuard;
   onSubmitted: () => void;
   /** 全部题目,顺序与树视图一致(章号 → order → name)。上/下一题按它取邻居。 */
-  siblings: () => ProgramLab[];
+  siblings: () => LabEntry[];
 }
 
 /** 题目面板：单例 webview，切换题目时复用同一个面板。 */
@@ -27,7 +27,7 @@ export class LabPanel {
 
   private readonly panel: vscode.WebviewPanel;
   private readonly disposables: vscode.Disposable[] = [];
-  private lab!: ProgramLab;
+  private lab!: LabEntry;
   private cases: LoadedCase[] = [];
   /** quiz 题目的渲染结果，提交后回填反馈区时复用。 */
   private quizViews: QuizQuestionView[] = [];
@@ -56,14 +56,14 @@ export class LabPanel {
     );
   }
 
-  static async show(lab: ProgramLab, deps: PanelDeps): Promise<void> {
+  static async show(lab: LabEntry, deps: PanelDeps): Promise<void> {
     if (!LabPanel.current) LabPanel.current = new LabPanel(deps);
     await LabPanel.current.load(lab);
     LabPanel.current.panel.reveal(vscode.ViewColumn.One);
   }
 
   /** 当前面板正在显示的题目，供「提交当前题目」命令使用。 */
-  static activeLab(): ProgramLab | undefined {
+  static activeLab(): LabEntry | undefined {
     return LabPanel.current?.lab;
   }
 
@@ -71,66 +71,78 @@ export class LabPanel {
     await LabPanel.current?.submit();
   }
 
-  private async load(lab: ProgramLab): Promise<void> {
+  private async load(lab: LabEntry): Promise<void> {
     this.lab = lab;
     this.panel.title = lab.title;
 
-    const [readme, cases] = await Promise.all([
-      renderReadme(lab, this.panel.webview),
-      loadTestCases(lab),
-    ]);
-    this.cases = cases;
+    const readme = await renderReadme(lab, this.panel.webview);
+    this.cases = [];
+    this.quizViews = [];
 
-    // 渲染结果存下来：提交某一题后要用同一份 HTML 回填反馈区，
-    // 否则题解会退化成纯文本（Markdown 和公式都不生效）。
-    this.quizViews = (lab.quizQuestions ?? []).map((question) => ({
-      ...question,
-      stemHtml: renderMarkdownFragment(question.stem, lab, this.panel.webview),
-      optionHtml: question.options.map((option) => renderMarkdownFragment(option, lab, this.panel.webview)),
-      hintHtml: question.hint ? renderMarkdownFragment(question.hint, lab, this.panel.webview) : undefined,
-      explanationHtml: renderMarkdownFragment(question.explanation, lab, this.panel.webview),
-    }));
+    if (lab.type === "quiz") {
+      // 渲染结果存下来：提交某一题后要用同一份 HTML 回填反馈区，
+      // 否则题解会退化成纯文本（Markdown 和公式都不生效）。
+      this.quizViews = lab.quizQuestions.map((question) => ({
+        ...question,
+        stemHtml: renderMarkdownFragment(question.stem, lab, this.panel.webview),
+        optionHtml: question.options.map((option) => renderMarkdownFragment(option, lab, this.panel.webview)),
+        hintHtml: question.hint ? renderMarkdownFragment(question.hint, lab, this.panel.webview) : undefined,
+        explanationHtml: renderMarkdownFragment(question.explanation, lab, this.panel.webview),
+      }));
+      this.panel.webview.html = renderQuizPanelHtml({
+        webview: this.panel.webview,
+        extensionPath: this.deps.context.extensionPath,
+        lab,
+        readmeHtml: readme.html,
+        questions: this.quizViews,
+        quizProgress: this.deps.progress.getQuiz(lab.id),
+      });
+      return;
+    }
 
-    this.panel.webview.html = lab.type === "quiz"
-      ? renderQuizPanelHtml({
-          webview: this.panel.webview,
-          extensionPath: this.deps.context.extensionPath,
-          lab,
-          readmeHtml: readme.html,
-          questions: this.quizViews,
-          quizProgress: this.deps.progress.getQuiz(lab.id),
-        })
-      : renderPanelHtml({
-          webview: this.panel.webview,
-          extensionPath: this.deps.context.extensionPath,
-          lab,
-          readmeHtml: readme.html,
-          cases,
-          progress: this.deps.progress.get(lab.id),
-          nav: this.navFor(lab),
-        });
+    if (lab.type === "project") {
+      this.panel.webview.html = renderProjectPanelHtml({
+        webview: this.panel.webview,
+        extensionPath: this.deps.context.extensionPath,
+        lab,
+        readmeHtml: readme.html,
+        progress: this.deps.progress.getProject(lab.id),
+        nav: this.navFor(lab),
+      });
+      return;
+    }
+
+    this.cases = await loadTestCases(lab);
+    this.panel.webview.html = renderPanelHtml({
+      webview: this.panel.webview,
+      extensionPath: this.deps.context.extensionPath,
+      lab,
+      readmeHtml: readme.html,
+      cases: this.cases,
+      progress: this.deps.progress.get(lab.id),
+      nav: this.navFor(lab),
+    });
   }
 
   /**
-   * 取代码题序列里的前后邻居。
+   * 取可导航题目序列里的前后邻居。
    *
-   * 只在 program 之间走 —— 跳到选择题的话那一页没有这两个按钮,用户就回不来了,
-   * 等于把人送进死路。所以这里先过滤掉 quiz 再找邻居。
+   * 代码题和 Project 共用这一组导航；选择题没有这两个按钮，所以先过滤掉 quiz。
    */
-  private navFor(lab: ProgramLab): PanelNav {
-    if (lab.type !== "program") return {};
-    const programs = this.deps.siblings().filter((item) => item.type === "program");
-    const index = programs.findIndex((item) => item.id === lab.id);
+  private navFor(lab: LabEntry): PanelNav {
+    if (lab.type === "quiz") return {};
+    const navigable = this.deps.siblings().filter((item) => item.type !== "quiz");
+    const index = navigable.findIndex((item) => item.id === lab.id);
     if (index < 0) return {};
 
     const at = (offset: number) => {
-      const target = programs[index + offset];
+      const target = navigable[index + offset];
       return target ? { name: target.id, title: target.title } : undefined;
     };
     return { prev: at(-1), next: at(1) };
   }
 
-  private async handleMessage(message: { type: string; questionId?: string; selected?: number; labName?: string }): Promise<void> {
+  private async handleMessage(message: { type: string; questionId?: string; selected?: number; labName?: string; filePath?: string }): Promise<void> {
     switch (message.type) {
       case "submit":
         await this.submit();
@@ -139,7 +151,10 @@ export class LabPanel {
         await this.navigate(message.labName);
         return;
       case "openSource":
-        await this.openSource();
+        await this.openSource(message.filePath);
+        return;
+      case "openProjectFile":
+        if (this.lab.type === "project") await this.openSource(message.filePath);
         return;
       case "showHistory":
         await vscode.commands.executeCommand("dsaMastery.showHistory", this.lab.id);
@@ -186,8 +201,39 @@ export class LabPanel {
     await this.load(target);
   }
 
-  private async openSource(): Promise<void> {
-    const document = await vscode.workspace.openTextDocument(studentSourcePath(this.lab));
+  private async openSource(filePath?: string): Promise<void> {
+    let sourcePath: string;
+    if (this.lab.type === "project") {
+      let studentFile = filePath
+        ? this.lab.studentFiles.find((file) => file.relativePath === filePath)
+        : undefined;
+      if (!studentFile) {
+        if (this.lab.studentFiles.length === 1) {
+          studentFile = this.lab.studentFiles[0];
+        } else {
+          interface ProjectFilePick extends vscode.QuickPickItem {
+            filePath: string;
+          }
+          const items: ProjectFilePick[] = this.lab.studentFiles.map((file) => ({
+            label: `$(file-code) ${path.basename(file.relativePath)}`,
+            description: file.taskId,
+            detail: file.relativePath,
+            filePath: file.relativePath,
+          }));
+          const picked = await vscode.window.showQuickPick(items, {
+            title: `${this.lab.title} · 选择学生文件`,
+            placeHolder: "只显示 student/ 目录中的可作答文件",
+          });
+          studentFile = picked ? this.lab.studentFiles.find((file) => file.relativePath === picked.filePath) : undefined;
+        }
+      }
+      if (!studentFile) return;
+      sourcePath = studentFile.absolutePath;
+    } else {
+      if (this.lab.type !== "program") return;
+      sourcePath = studentSourcePath(this.lab);
+    }
+    const document = await vscode.workspace.openTextDocument(sourcePath);
     await vscode.window.showTextDocument(document, vscode.ViewColumn.Beside);
   }
 
@@ -197,39 +243,66 @@ export class LabPanel {
    * 提交是状态唯一的写入时机 —— 只改代码不提交不会影响任何进度显示。
    */
   private async submit(): Promise<void> {
+    if (this.lab.type === "quiz") {
+      void vscode.window.showInformationMessage("选择题请在题目中逐题作答。");
+      return;
+    }
     if (this.submitting) return;
     this.submitting = true;
     void this.panel.webview.postMessage({ type: "submitting" });
 
     try {
       // 先保存未落盘的改动，否则判的是旧代码。
-      const sourcePath = studentSourcePath(this.lab);
-      const open = vscode.workspace.textDocuments.find((doc) => doc.fileName === sourcePath);
-      if (open?.isDirty) await open.save();
+      if (this.lab.type === "program") {
+        const sourcePath = studentSourcePath(this.lab);
+        const open = vscode.workspace.textDocuments.find((doc) => comparablePath(doc.fileName) === comparablePath(sourcePath));
+        if (open?.isDirty) await open.save();
+      } else if (this.lab.type === "project") {
+        await this.saveProjectFiles(this.lab);
+      }
 
       if (!(await this.deps.guard.ensureReady(this.lab))) {
-        void this.panel.webview.postMessage({ type: "submitAborted" });
+        void this.panel.webview.postMessage({ type: this.lab.type === "project" ? "projectSubmitAborted" : "submitAborted" });
         return;
       }
 
-      const result = await scoreLab(this.deps.repoRoot, this.lab.relativePath);
-      const progress = await this.deps.progress.recordSubmission(this.lab, result);
+      if (this.lab.type === "project") {
+        const result = await scoreProject(this.deps.repoRoot, this.lab.relativePath);
+        const progress = await this.deps.progress.recordProjectSubmission(this.lab, result);
+        void this.panel.webview.postMessage({
+          type: "projectResult",
+          html: renderProjectResultHtml(result, progress),
+        });
+        this.deps.onSubmitted();
+        void this.notifyProject(result);
+      } else {
+        const result = await scoreLab(this.deps.repoRoot, this.lab.relativePath);
+        const progress = await this.deps.progress.recordSubmission(this.lab, result);
 
-      void this.panel.webview.postMessage({
-        type: "result",
-        html: renderResultHtml(result, progress),
-      });
-      this.deps.onSubmitted();
-      // 不 await：通知要等用户点击或自动消失才 resolve，
-      // 挂在这里会让 submitting 锁迟迟不释放，后续提交全部被挡掉。
-      void this.notify(result);
+        void this.panel.webview.postMessage({
+          type: "result",
+          html: renderResultHtml(result, progress),
+        });
+        this.deps.onSubmitted();
+        // 不 await：通知要等用户点击或自动消失才 resolve，
+        // 挂在这里会让 submitting 锁迟迟不释放，后续提交全部被挡掉。
+        void this.notify(result);
+      }
     } catch (error) {
       const message = error instanceof CliError ? error.message : String(error);
-      void this.panel.webview.postMessage({ type: "submitFailed", message });
+      void this.panel.webview.postMessage({ type: this.lab.type === "project" ? "projectSubmitFailed" : "submitFailed", message });
       void vscode.window.showErrorMessage(`提交失败：${message}`);
     } finally {
       this.submitting = false;
     }
+  }
+
+  private async saveProjectFiles(lab: ProjectLab): Promise<void> {
+    const allowed = new Set(lab.studentFiles.map((file) => comparablePath(file.absolutePath)));
+    const dirtyDocuments = vscode.workspace.textDocuments.filter((document) =>
+      document.isDirty && allowed.has(comparablePath(document.fileName)),
+    );
+    await Promise.all(dirtyDocuments.map((document) => document.save()));
   }
 
   /** 判题结果通知。WA 时提供并排查看完整输出的入口。 */
@@ -250,6 +323,27 @@ export class LabPanel {
     if (choice && failed) await this.openDiff(failed.id);
   }
 
+  private async notifyProject(result: ProjectScoreResult): Promise<void> {
+    if (result.internalError) {
+      await vscode.window.showErrorMessage("Project 判题遇到内部错误，请查看任务级结果后重试。");
+      return;
+    }
+    if (result.automatedFull && result.manualPending > 0) {
+      await vscode.window.showInformationMessage(
+        `自动判题通过：${this.lab.title}（${result.automatedScore}/${result.automatedMax}），待人工评审 ${result.manualPending} 分。`,
+      );
+      return;
+    }
+    if (result.automatedFull) {
+      await vscode.window.showInformationMessage(`通过：${this.lab.title}（${result.provisionalTotal}/${result.total}）`);
+      return;
+    }
+    const failed = result.tasks.find((task) => task.kind !== "manual" && task.status !== "AC");
+    await vscode.window.showWarningMessage(
+      `自动判题未满：${failed ? `${failed.id} ${failed.status}` : "请查看任务结果"}（${result.automatedScore}/${result.automatedMax}）`,
+    );
+  }
+
   /**
    * 用 VSCode 原生 diff 并排显示实际输出与期望输出。
    *
@@ -257,6 +351,7 @@ export class LabPanel {
    * 临时文件。这里用 run --case 单独跑，避免重跑全部用例。
    */
   private async openDiff(caseId: string): Promise<void> {
+    if (this.lab.type !== "program") return;
     const testCase = this.cases.find((item) => item.id === caseId);
     if (!testCase) return;
 
@@ -281,6 +376,7 @@ export class LabPanel {
 
   /** 直接运行已编译的可执行文件取得完整 stdout。 */
   private async captureOutput(testCase: LoadedCase): Promise<string> {
+    if (this.lab.type !== "program") throw new CliError("Project/选择题不支持单文件输出对比。");
     const { spawn } = await import("node:child_process");
     const executable = path.join(
       this.lab.labPath,
@@ -318,4 +414,9 @@ export class LabPanel {
     for (const item of this.disposables) item.dispose();
     this.panel.dispose();
   }
+}
+
+function comparablePath(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 }

--- a/tools/vscode-extension/src/panelHtml.ts
+++ b/tools/vscode-extension/src/panelHtml.ts
@@ -1,9 +1,10 @@
 import path from "node:path";
 import * as vscode from "vscode";
-import type { ScoreResult } from "./cli";
-import type { ProgramLab, TestCase } from "./labIndex";
+import type { ProjectScoreResult, ScoreResult } from "./cli";
+import type { LoadedTestCase, ProjectLab, ProjectTask, ProgramLab, QuizLab } from "./labIndex";
 import type { LabProgress } from "./progress";
 import type { QuizProgress } from "./progress";
+import { projectProgressPassed, type ProjectProgress, type ProjectSubmissionSummary, type ProjectTaskSubmissionSummary } from "./projectProgress";
 import type { QuizQuestion } from "./quiz";
 
 export type QuizQuestionView = QuizQuestion & {
@@ -13,7 +14,7 @@ export type QuizQuestionView = QuizQuestion & {
   explanationHtml: string;
 };
 
-type LoadedCase = TestCase & { inputText: string; expectedText: string };
+type LoadedCase = LoadedTestCase;
 
 function escapeHtml(value: string): string {
   return value
@@ -29,7 +30,7 @@ function nonce(): string {
 
 export function renderQuizPanelHtml(
   // 排除 nav:上/下一题只在代码题里出现,选择题面板不接这个字段。
-  options: Omit<PanelOptions, "cases" | "progress" | "nav"> & { questions: QuizQuestionView[]; quizProgress?: QuizProgress },
+  options: { webview: vscode.Webview; extensionPath: string; lab: QuizLab; readmeHtml: string; questions: QuizQuestionView[]; quizProgress?: QuizProgress },
 ): string {
   const { webview, extensionPath, lab, readmeHtml, questions, quizProgress } = options;
   const cspNonce = nonce();
@@ -404,6 +405,294 @@ window.addEventListener("message", (event) => {
 </script>
 </body>
 </html>`;
+}
+
+interface ProjectPanelOptions {
+  webview: vscode.Webview;
+  extensionPath: string;
+  lab: ProjectLab;
+  readmeHtml: string;
+  progress: ProjectProgress | undefined;
+  nav: PanelNav;
+}
+
+/** Project 面板：题面、task 图和自动判题结果各自保留层级，不压平成 program 表格。 */
+export function renderProjectPanelHtml(options: ProjectPanelOptions): string {
+  const { webview, extensionPath, lab, readmeHtml, progress, nav } = options;
+  const cspNonce = nonce();
+  const initialInspectorOpen = Boolean(progress?.lastSubmission);
+  const styleUri = webview.asWebviewUri(
+    vscode.Uri.file(path.join(extensionPath, "media", "panel.css")),
+  );
+  const katexCssUri = webview.asWebviewUri(
+    vscode.Uri.file(path.join(extensionPath, "media", "katex", "katex.min.css")),
+  );
+  const taskHtml = lab.tasks
+    .map((task) => renderProjectTask(task, lab.studentFiles.filter((file) => file.taskId === task.id)))
+    .join("\n");
+  const resultHtml = progress?.lastSubmission
+    ? renderStoredProjectResult(progress.lastSubmission)
+    : '<p class="inspector-empty">提交后，Project 的自动判题结果会按 task、case 和 CTest 展示在这里。</p>';
+
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} data:; style-src ${webview.cspSource}; font-src ${webview.cspSource}; script-src 'nonce-${cspNonce}';" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="stylesheet" href="${katexCssUri}" />
+<link rel="stylesheet" href="${styleUri}" />
+<title>${escapeHtml(lab.title)}</title>
+</head>
+<body class="project-body">
+<div class="lab-page project-page">
+<div class="project-scroll-region">
+${renderProjectHeader(lab, progress)}
+<div class="lab-workspace project-workspace${initialInspectorOpen ? "" : " is-inspector-collapsed"}">
+  <main class="lab-reading-surface" aria-label="Project 题面与任务">
+    <article class="readme">${readmeHtml}</article>
+    <section class="project-task-overview" aria-labelledby="project-task-title">
+      <div class="project-section-heading"><span class="project-eyebrow">PROJECT TASK GRAPH</span><h2 id="project-task-title">任务与学生文件</h2></div>
+      ${taskHtml}
+    </section>
+  </main>
+  ${renderProjectInspector(resultHtml, initialInspectorOpen)}
+</div>
+</div>
+${renderProjectToolbar(nav)}
+</div>
+<script nonce="${cspNonce}">
+const vscodeApi = acquireVsCodeApi();
+const submitButton = document.getElementById("submit");
+const result = document.getElementById("project-result");
+const workspace = document.querySelector(".project-workspace");
+const inspector = document.getElementById("project-inspector");
+const inspectorContent = document.getElementById("project-inspector-content");
+const inspectorToggle = document.getElementById("project-inspector-toggle");
+const actionbar = document.querySelector(".lab-actionbar");
+const projectPage = document.querySelector(".project-page");
+const readingSurface = document.querySelector(".lab-reading-surface");
+
+function syncActionbarLayout() {
+  if (!actionbar || !projectPage || !readingSurface) return;
+  const surfaceRect = readingSurface.getBoundingClientRect();
+  const horizontalInset = Math.min(14, Math.max(10, surfaceRect.width * 0.025));
+  actionbar.style.left = \`\${surfaceRect.left + horizontalInset}px\`;
+  actionbar.style.right = "auto";
+  actionbar.style.width = \`\${Math.max(0, surfaceRect.width - horizontalInset * 2)}px\`;
+  projectPage.style.setProperty("--lab-actionbar-reserve", \`\${Math.ceil(actionbar.getBoundingClientRect().height + 32)}px\`);
+}
+
+function setInspectorOpen(open) {
+  if (!inspector || !inspectorContent || !inspectorToggle) return;
+  inspector.classList.toggle("is-collapsed", !open);
+  if (workspace) workspace.classList.toggle("is-inspector-collapsed", !open);
+  inspectorContent.hidden = !open;
+  inspectorToggle.setAttribute("aria-expanded", String(open));
+  inspectorToggle.setAttribute("aria-label", open ? "收起自动判题结果" : "展开自动判题结果");
+  inspectorToggle.querySelector(".inspector-toggle-text").textContent = open ? "收起" : "展开";
+}
+
+if (actionbar && projectPage && readingSurface) {
+  syncActionbarLayout();
+  if (typeof ResizeObserver !== "undefined") {
+    const observer = new ResizeObserver(syncActionbarLayout);
+    observer.observe(actionbar);
+    observer.observe(readingSurface);
+  } else {
+    window.addEventListener("resize", syncActionbarLayout);
+  }
+}
+
+submitButton.addEventListener("click", () => vscodeApi.postMessage({ type: "submit" }));
+document.getElementById("open-source").addEventListener("click", () => vscodeApi.postMessage({ type: "openSource" }));
+document.querySelectorAll("[data-project-file]").forEach(button => button.addEventListener("click", () => {
+  vscodeApi.postMessage({ type: "openProjectFile", filePath: button.dataset.projectFile });
+}));
+if (inspectorToggle) inspectorToggle.addEventListener("click", () => {
+  setInspectorOpen(inspectorToggle.getAttribute("aria-expanded") !== "true");
+});
+for (const id of ["nav-prev", "nav-next"]) {
+  const button = document.getElementById(id);
+  if (!button) continue;
+  button.addEventListener("click", () => {
+    if (button.disabled || !button.dataset.target) return;
+    vscodeApi.postMessage({ type: "navigate", labName: button.dataset.target });
+  });
+}
+
+window.addEventListener("message", event => {
+  const message = event.data;
+  if (message.type === "submitting") {
+    setInspectorOpen(true);
+    submitButton.disabled = true;
+    submitButton.textContent = "判题中…";
+    result.innerHTML = '<p class="pending">正在保存学生文件，并运行 Project 的自动任务…</p>';
+  } else if (message.type === "projectResult") {
+    setInspectorOpen(true);
+    submitButton.disabled = false;
+    submitButton.textContent = "提交 Project";
+    result.innerHTML = message.html;
+    result.scrollIntoView({ behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth", block: "nearest" });
+  } else if (message.type === "projectSubmitFailed") {
+    setInspectorOpen(true);
+    submitButton.disabled = false;
+    submitButton.textContent = "提交 Project";
+    result.innerHTML = '<p class="error">提交失败：' + message.message + '</p>';
+  } else if (message.type === "projectSubmitAborted") {
+    submitButton.disabled = false;
+    submitButton.textContent = "提交 Project";
+  }
+});
+setInspectorOpen(${initialInspectorOpen});
+</script>
+</body>
+</html>`;
+}
+
+function renderProjectHeader(lab: ProjectLab, progress: ProjectProgress | undefined): string {
+  const meta = [
+    lab.difficulty && `难度 ${escapeHtml(lab.difficulty)}`,
+    lab.duration && `预计 ${escapeHtml(lab.duration)}`,
+    `题号 ${escapeHtml(lab.id)}`,
+    `第 ${lab.chapter} 章 · ${escapeHtml(lab.chapterTitle)}`,
+  ].filter(Boolean).join(" · ");
+  const badge = !progress || progress.submissionCount === 0
+    ? '<span class="badge fresh">Project · 未提交</span>'
+    : progress.internalError
+      ? '<span class="badge attempted">评测内部错误</span>'
+      : projectProgressPassed(progress)
+      ? '<span class="badge passed">已完成</span>'
+      : progress.automatedFull && progress.manualPending > 0
+        ? '<span class="badge attempted">自动通过 · 待人工</span>'
+        : `<span class="badge attempted">自动 ${formatNumber(progress.automatedScore)}/${formatNumber(progress.automatedMax)}</span>`;
+  return `<header class="lab-header"><div class="title-row"><h1>${escapeHtml(lab.title)}</h1>${badge}</div><p class="meta">${meta}</p></header>`;
+}
+
+function renderProjectTask(task: ProjectTask, files: ProjectLab["studentFiles"]): string {
+  const kindLabel = task.kind === "stdio" ? "stdio 自动判题" : task.kind === "ctest" ? "CTest 自动判题" : "人工评审";
+  const dependencies = task.dependsOn.length ? task.dependsOn.map((id) => `<code>${escapeHtml(id)}</code>`).join("、") : "无";
+  const fileHtml = files.length === 0
+    ? '<span class="project-empty">暂无学生文件</span>'
+    : files.map((file) => `<button type="button" class="project-file-button" data-project-file="${escapeHtml(file.relativePath)}"><code>${escapeHtml(file.relativePath)}</code><span>打开</span></button>`).join("");
+  let details = "";
+  if (task.kind === "stdio") {
+    const cases = task.cases ?? [];
+    details = cases.length === 0
+      ? '<p class="project-empty">没有可展示的公开 case。</p>'
+      : `<div class="project-task-cases"><h4>公开 case（${cases.length} 个）</h4>${cases.map(renderProjectCase).join("")}</div>`;
+  } else if (task.kind === "ctest") {
+    const tests = task.ctestTests ?? [];
+    details = `<div class="project-task-tests"><h4>CTest 测试（${tests.length} 个）</h4><div class="project-test-list">${tests.map((test) => `<span class="project-test-chip"><code>${escapeHtml(test.name)}</code><span>${formatNumber(test.points)} 分</span></span>`).join("")}</div></div>`;
+  } else {
+    const checklist = task.checklist ?? [];
+    details = `<div class="project-manual"><span class="project-pending">PENDING · 待人工</span><ul>${checklist.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul></div>`;
+  }
+
+  return `<article class="project-task-card project-task-${task.kind}">
+  <header class="project-task-header"><div><span class="project-task-id">${escapeHtml(task.id)}</span><span class="project-task-kind">${kindLabel}</span></div><strong>${formatNumber(task.weight)} 分</strong></header>
+  <dl class="project-task-meta"><div><dt>路径</dt><dd><code>${escapeHtml(task.relativePath)}</code></dd></div><div><dt>依赖</dt><dd>${dependencies}</dd></div></dl>
+  <div class="project-task-files"><h4>学生文件</h4>${fileHtml}</div>
+  ${details}
+</article>`;
+}
+
+function renderProjectCase(testCase: LoadedCase): string {
+  return `<details class="case project-case"${testCase.tags?.includes("sample") ? " open" : ""}><summary><code>${escapeHtml(testCase.id)}</code><span class="points">${formatNumber(testCase.points)} 分</span></summary><div class="io"><div><h5>输入</h5><pre>${escapeHtml(testCase.inputText)}</pre></div><div><h5>期望输出</h5><pre>${escapeHtml(testCase.expectedText)}</pre></div></div></details>`;
+}
+
+function renderProjectInspector(resultHtml: string, initialOpen: boolean): string {
+  return `<aside id="project-inspector" class="lab-inspector${initialOpen ? "" : " is-collapsed"}" aria-label="自动判题结果"><div class="inspector-header"><div class="inspector-title-group"><span class="inspector-eyebrow">检查器</span><h2 class="inspector-title">自动判题结果</h2></div><button id="project-inspector-toggle" class="inspector-toggle" type="button" aria-expanded="${initialOpen}" aria-controls="project-inspector-content" aria-label="${initialOpen ? "收起自动判题结果" : "展开自动判题结果"}"><span class="inspector-toggle-glyph" aria-hidden="true"></span><span class="inspector-toggle-text">${initialOpen ? "收起" : "展开"}</span></button></div><div id="project-inspector-content" class="inspector-content"${initialOpen ? "" : " hidden"}><div id="project-result" class="result" aria-live="polite">${resultHtml}</div></div></aside>`;
+}
+
+function renderProjectToolbar(nav: PanelNav): string {
+  const prev = nav.prev
+    ? `<button id="nav-prev" class="lab-button lab-button-secondary lab-button-nav" type="button" data-target="${escapeHtml(nav.prev.name)}" title="${escapeHtml(nav.prev.title)}">上一题</button>`
+    : '<button id="nav-prev" class="lab-button lab-button-secondary lab-button-nav" type="button" disabled title="已经是第一题">上一题</button>';
+  const next = nav.next
+    ? `<button id="nav-next" class="lab-button lab-button-secondary lab-button-nav" type="button" data-target="${escapeHtml(nav.next.name)}" title="${escapeHtml(nav.next.title)}">下一题</button>`
+    : '<button id="nav-next" class="lab-button lab-button-secondary lab-button-nav" type="button" disabled title="已经是最后一题">下一题</button>';
+  return `<nav class="lab-actionbar" aria-label="Project 操作"><div class="lab-actionbar-main"><button id="submit" class="lab-button lab-button-primary" type="button">提交 Project</button><button id="open-source" class="lab-button lab-button-secondary" type="button">选择学生文件</button></div><div class="lab-actionbar-nav">${prev}${next}</div></nav>`;
+}
+
+function renderProjectResultTask(task: ProjectTaskSubmissionSummary): string {
+  const score = task.kind === "manual"
+    ? `<span class="project-pending">PENDING · ${formatNumber(task.weight)} 分待人工</span>`
+    : `<span>${verdictLabel(task.status)} · ${formatNumber(task.score ?? 0)}/${formatNumber(task.maxScore ?? 0)} · 加权 ${formatNumber(task.weightedScore)}/${formatNumber(task.weight)}</span>`;
+  let nested = "";
+  if (task.kind === "stdio") {
+    const rows = (task.cases ?? []).map((item) => {
+      const difference = item.comparison?.difference;
+      const detail = difference && !item.comparison?.equal
+        ? `<tr class="difference"><td colspan="4">首处差异：${difference.kind === "token" ? `第 ${difference.index} 个 token` : `第 ${difference.line} 行第 ${difference.column} 列`} · 期望 <code>${escapeHtml(JSON.stringify(difference.expected))}</code> · 实际 <code>${escapeHtml(JSON.stringify(difference.actual))}</code></td></tr>`
+        : "";
+      const stderr = item.stderr?.trim()
+        ? `<tr class="stderr-row"><td colspan="4"><details><summary>stderr</summary><pre>${escapeHtml(item.stderr.trim().slice(0, 1000))}</pre></details></td></tr>`
+        : "";
+      return `<tr class="verdict-${item.verdict}"><td><code>${escapeHtml(item.id)}</code></td><td class="verdict">${item.verdict}</td><td class="num">${Math.round(item.durationMs)} ms</td><td class="num">${formatNumber(item.points)}/${formatNumber(item.maxPoints)}</td></tr>${detail}${stderr}`;
+    }).join("");
+    const diagnostic = task.diagnostic?.trim()
+      ? `<pre class="diagnostic project-diagnostic">${escapeHtml(task.diagnostic.trim().slice(0, 4000))}</pre>`
+      : "";
+    nested = `${diagnostic}${rows ? `<table class="cases-table project-result-table"><thead><tr><th>case</th><th>结果</th><th>耗时</th><th>得分</th></tr></thead><tbody>${rows}</tbody></table>` : ""}`;
+  } else if (task.kind === "ctest") {
+    const rows = (task.tests ?? []).map((item) => {
+      const output = item.output?.trim()
+        ? `<tr class="stderr-row"><td colspan="4"><details><summary>CTest output</summary><pre>${escapeHtml(item.output.trim().slice(0, 2000))}</pre></details></td></tr>`
+        : "";
+      return `<tr class="verdict-${item.verdict}"><td><code>${escapeHtml(item.name)}</code></td><td class="verdict">${item.verdict}</td><td class="num">${Math.round(item.durationMs)} ms</td><td class="num">${formatNumber(item.points)}/${formatNumber(item.maxPoints)}</td></tr>${output}`;
+    }).join("");
+    const build = task.buildFailed
+      ? `<p class="project-build-status">构建失败（${task.buildPhase === "configure" ? "配置" : "编译"}），CTest 未运行。</p>`
+      : "";
+    nested = `${build}${rows ? `<table class="cases-table project-result-table"><thead><tr><th>CTest</th><th>结果</th><th>耗时</th><th>得分</th></tr></thead><tbody>${rows}</tbody></table>` : ""}`;
+  } else {
+    nested = `<ul class="project-result-checklist">${(task.checklist ?? []).map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
+  }
+  return `<section class="project-task-result"><div class="project-task-result-heading"><code>${escapeHtml(task.id)}</code>${score}</div>${nested}</section>`;
+}
+
+function renderProjectResultSummary(
+  summary: Pick<ProjectSubmissionSummary, "at" | "automatedScore" | "automatedMax" | "manualPending" | "provisionalTotal" | "total" | "automatedFull" | "internalError" | "tasks">,
+  submissionCount?: number,
+): string {
+  const finalPassed = projectProgressPassed(summary);
+  const pendingManual = summary.manualPending > 0;
+  const className = finalPassed ? "passed" : summary.internalError ? "failed" : "pending";
+  const headline = summary.internalError
+    ? "评测内部错误"
+    : finalPassed
+      ? "Project 完成"
+      : summary.automatedFull && pendingManual
+        ? "自动通过 · 待人工"
+        : "自动部分未满";
+  return `<div class="summary ${className}"><h3>${headline}</h3><div class="project-score-grid"><span><strong>Automated</strong>${formatNumber(summary.automatedScore)}/${formatNumber(summary.automatedMax)}</span><span><strong>Manual pending</strong>${formatNumber(summary.manualPending)}</span><span><strong>Provisional total</strong>${formatNumber(summary.provisionalTotal)}/${formatNumber(summary.total)}</span></div><p>${submissionCount ? `第 ${submissionCount} 次提交 · ` : ""}${escapeHtml(new Date(summary.at).toLocaleString())}</p>${summary.tasks.map(renderProjectResultTask).join("")}</div>`;
+}
+
+function renderStoredProjectResult(summary: ProjectSubmissionSummary): string {
+  return renderProjectResultSummary(summary, undefined);
+}
+
+/** 一次 Project 提交的完整嵌套结果。 */
+export function renderProjectResultHtml(result: ProjectScoreResult, progress: ProjectProgress): string {
+  return renderProjectResultSummary({ ...result, at: new Date().toISOString(), tasks: result.tasks.map((task) => {
+    if (task.kind === "manual") return { ...task, checklist: [...task.checklist] };
+    if (task.kind === "stdio") return {
+      ...task,
+      cases: task.judge.cases.map((item) => ({ id: item.id, verdict: item.verdict, points: item.points, maxPoints: item.maxPoints, durationMs: item.durationMs, stderr: item.stderr, comparison: item.comparison })),
+      diagnostic: (task.judge.compilation.stderr || task.judge.compilation.stdout).trim() || undefined,
+    };
+    return {
+      ...task,
+      tests: task.tests.map((item) => ({ name: item.name, verdict: item.verdict, points: item.points, maxPoints: item.maxPoints, durationMs: item.durationMs, output: item.output })),
+      buildFailed: task.build ? !task.build.ok : undefined,
+      buildPhase: task.build?.phase,
+    };
+  }) }, progress.submissionCount);
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
 }
 
 function renderHeader(lab: ProgramLab, progress: LabProgress | undefined): string {

--- a/tools/vscode-extension/src/progress.ts
+++ b/tools/vscode-extension/src/progress.ts
@@ -1,14 +1,20 @@
 import { copyFile, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import * as vscode from "vscode";
-import type { CaseResult, ScoreResult, Verdict } from "./cli";
-import { studentSourcePath, type ProgramLab } from "./labIndex";
+import type { CaseResult, ProjectScoreResult, ScoreResult, Verdict } from "./cli";
+import { studentSourcePath, type LabEntry, type ProjectLab, type ProgramLab } from "./labIndex";
 import type { QuizQuestion } from "./quiz";
 import { backfillEvents } from "./stats";
 import { remapEventKeys, remapRecordKeys } from "./progressKeys";
 import { mergeLabProgress, mergeQuizProgress } from "./progressMerge";
+import {
+  projectProgressPassed,
+  summarizeProjectSubmission,
+  type ProjectProgress,
+} from "./projectProgress";
 
 const STATE_KEY = "dsaMastery.progress.v1";
+const PROJECT_STATE_KEY = "dsaMastery.projectProgress.v1";
 const SCHEMA_VERSION = 3;
 const EVENT_SCHEMA_VERSION = 2;
 
@@ -32,7 +38,7 @@ export interface ActivityEvent {
   at: string;
   kind: "submit" | "pass";
   labName: string;
-  labType: "program" | "quiz";
+  labType: "program" | "quiz" | "project";
 }
 
 export interface SubmissionCase {
@@ -94,8 +100,17 @@ interface ProgressStore {
   events: ActivityEvent[];
 }
 
+interface ProjectStore {
+  schemaVersion: 1;
+  projects: Record<string, ProjectProgress>;
+}
+
 function emptyStore(): ProgressStore {
   return { schemaVersion: SCHEMA_VERSION, labs: {}, quizzes: {}, events: [] };
+}
+
+function emptyProjectStore(): ProjectStore {
+  return { schemaVersion: 1, projects: {} };
 }
 
 /**
@@ -131,14 +146,16 @@ function snapshotId(when: Date): string {
  * 做题进度。
  *
  * 轻量索引存 globalState，源码快照存 globalStorageUri 下的文件 —— globalState 在
- * VSCode 启动时会整份读入内存，不适合堆放源码。两者都位于用户数据目录，不进仓库，
+ * VSCode 启动时会整份读入内存，不适合堆放源码。这些状态都位于用户数据目录，不进仓库，
  * 也不会被 lab:clean 删除（后者只清理各 lab 的 .lab-cache/）。
  */
 export class ProgressTracker {
   private store: ProgressStore;
+  private projectStore: ProjectStore;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     this.store = this.load();
+    this.projectStore = this.loadProjects();
   }
 
   private load(): ProgressStore {
@@ -171,20 +188,33 @@ export class ProgressTracker {
     await this.context.globalState.update(STATE_KEY, this.store);
   }
 
+  private loadProjects(): ProjectStore {
+    const raw = this.context.globalState.get<ProjectStore>(PROJECT_STATE_KEY);
+    if (!raw || typeof raw !== "object" || raw.schemaVersion !== 1 || !raw.projects || typeof raw.projects !== "object") {
+      return emptyProjectStore();
+    }
+    return { schemaVersion: 1, projects: raw.projects };
+  }
+
+  private async persistProjects(): Promise<void> {
+    await this.context.globalState.update(PROJECT_STATE_KEY, this.projectStore);
+  }
+
   /**
    * v2 → v3：把目录名主键迁移为稳定 labId。
    *
    * 只有题目扫描完成后才有足够的 README 元数据建立别名。迁移前保存完整备份；
    * 旧源码快照不移动，HistoryEntry.snapshot 继续指向原来的文件。
    */
-  async migrateLabKeys(labs: readonly ProgramLab[]): Promise<void> {
+  async migrateLabKeys(labs: readonly LabEntry[]): Promise<void> {
     const aliases = labs.flatMap((lab) =>
       [lab.name, ...lab.legacyNames].map((name) => ({ id: lab.id, name })),
     );
     const program = remapRecordKeys(this.store.labs, aliases, mergeLabProgress);
     const quiz = remapRecordKeys(this.store.quizzes, aliases, mergeQuizProgress);
+    const project = remapRecordKeys(this.projectStore.projects, aliases, mergeProjectProgress);
     const activity = remapEventKeys(this.store.events, aliases);
-    const changed = program.changed || quiz.changed || activity.changed || this.store.schemaVersion !== SCHEMA_VERSION;
+    const changed = program.changed || quiz.changed || project.changed || activity.changed || this.store.schemaVersion !== SCHEMA_VERSION;
     if (!changed) return;
 
     await this.context.globalState.update(`${STATE_KEY}.backup.v${this.store.schemaVersion}.${Date.now()}`, this.store);
@@ -194,7 +224,8 @@ export class ProgressTracker {
       quizzes: quiz.records,
       events: activity.events,
     };
-    await this.persist();
+    this.projectStore = { schemaVersion: 1, projects: project.records };
+    await Promise.all([this.persist(), this.persistProjects()]);
   }
 
   /**
@@ -225,6 +256,10 @@ export class ProgressTracker {
 
   getQuiz(labId: string): QuizProgress | undefined {
     return this.store.quizzes[labId];
+  }
+
+  getProject(labId: string): ProjectProgress | undefined {
+    return this.projectStore.projects[labId];
   }
 
   async recordQuizAnswer(
@@ -275,13 +310,18 @@ export class ProgressTracker {
   /**
    * 章节头部显示的「已通过/总数」。
    *
-   * 必须收 lab 对象而不是名字 —— 代码题和选择题的进度存在两张表里,
-   * 只有 `type` 能决定去哪张表查。收名字的版本会把选择题全算成未通过。
+   * 必须收 lab 对象而不是名字 —— Program、Quiz、Project 的进度存在不同状态表里,
+   * 只有 `type` 能决定去哪张表查。收名字的版本会把非 Program 题型算错。
    */
-  countPassed(labs: ProgramLab[]): number {
-    return labs.filter((lab) =>
-      lab.type === "quiz" ? this.store.quizzes[lab.id]?.passed : this.store.labs[lab.id]?.passed,
-    ).length;
+  countPassed(labs: readonly LabEntry[]): number {
+    return labs.filter((lab) => {
+      if (lab.type === "quiz") return this.store.quizzes[lab.id]?.passed;
+      if (lab.type === "project") {
+        const project = this.projectStore.projects[lab.id];
+        return project ? projectProgressPassed(project) : false;
+      }
+      return this.store.labs[lab.id]?.passed;
+    }).length;
   }
 
   /**
@@ -348,6 +388,46 @@ export class ProgressTracker {
     return progress;
   }
 
+  /**
+   * 记录 Project 的最近一次自动判题摘要。
+   *
+   * Project 不生成单文件历史快照：一个 Project 可能同时包含多个 task 和多种文件，
+   * 本 MVP 只保存可恢复 UI 状态的轻量摘要，避免把完整 CTest 输出和多文件副本塞进 globalState。
+   */
+  async recordProjectSubmission(lab: ProjectLab, result: ProjectScoreResult): Promise<ProjectProgress> {
+    const at = new Date().toISOString();
+    const existing = this.projectStore.projects[lab.id];
+    const progress: ProjectProgress = existing ?? {
+      submissionCount: 0,
+      automatedScore: 0,
+      automatedMax: result.automatedMax,
+      manualPending: result.manualPending,
+      provisionalTotal: result.provisionalTotal,
+      total: result.total,
+      automatedFull: result.automatedFull,
+      internalError: result.internalError,
+    };
+
+    progress.submissionCount += 1;
+    progress.automatedScore = result.automatedScore;
+    progress.automatedMax = result.automatedMax;
+    progress.manualPending = result.manualPending;
+    progress.provisionalTotal = result.provisionalTotal;
+    progress.total = result.total;
+    progress.automatedFull = result.automatedFull;
+    progress.internalError = result.internalError;
+    progress.lastSubmission = summarizeProjectSubmission(result, at);
+
+    this.projectStore.projects[lab.id] = progress;
+    this.appendEvent({ at, kind: "submit", labName: lab.id, labType: "project" });
+    if (projectProgressPassed(progress)) {
+      this.appendEvent({ at, kind: "pass", labName: lab.id, labType: "project" });
+    }
+
+    await Promise.all([this.persist(), this.persistProjects()]);
+    return progress;
+  }
+
   /** 把当前 student 源码复制到快照目录，返回相对 globalStorage 的路径。 */
   private async saveSnapshot(lab: ProgramLab, id: string): Promise<string> {
     const relativeDir = path.join("submissions", lab.id, id);
@@ -380,9 +460,30 @@ export class ProgressTracker {
 
   async resetAll(): Promise<void> {
     this.store = emptyStore();
-    await this.persist();
+    this.projectStore = emptyProjectStore();
+    await Promise.all([this.persist(), this.persistProjects()]);
     await rm(this.submissionsRoot(), { recursive: true, force: true });
   }
+}
+
+function mergeProjectProgress(stable: ProjectProgress, legacy: ProjectProgress): ProjectProgress {
+  const latest = [stable.lastSubmission, legacy.lastSubmission]
+    .filter((entry): entry is NonNullable<ProjectProgress["lastSubmission"]> => Boolean(entry))
+    .sort((left, right) => right.at.localeCompare(left.at))[0];
+  return {
+    ...(latest ? {
+      submissionCount: Math.max(stable.submissionCount, legacy.submissionCount),
+      automatedScore: latest.automatedScore,
+      automatedMax: latest.automatedMax,
+      manualPending: latest.manualPending,
+      provisionalTotal: latest.provisionalTotal,
+      total: latest.total,
+      automatedFull: latest.automatedFull,
+      internalError: latest.internalError,
+      lastSubmission: latest,
+    } : stable),
+    submissionCount: Math.max(stable.submissionCount, legacy.submissionCount),
+  };
 }
 
 function toSubmissionCase(item: CaseResult): SubmissionCase {

--- a/tools/vscode-extension/src/projectProgress.ts
+++ b/tools/vscode-extension/src/projectProgress.ts
@@ -1,0 +1,133 @@
+import type { ProjectScoreResult, ProjectStatus, ProjectTaskResult, Verdict } from "./cli";
+
+export interface ProjectCaseSummary {
+  id: string;
+  verdict: Verdict;
+  points: number;
+  maxPoints: number;
+  durationMs: number;
+  stderr?: string;
+  comparison?: {
+    equal: boolean;
+    difference?: {
+      kind: "token" | "line";
+      index?: number;
+      line?: number;
+      column?: number;
+      expected: string;
+      actual: string;
+    };
+  };
+}
+
+export interface ProjectTestSummary {
+  name: string;
+  verdict: Verdict;
+  points: number;
+  maxPoints: number;
+  durationMs: number;
+  output?: string;
+}
+
+export interface ProjectTaskSubmissionSummary {
+  id: string;
+  kind: "stdio" | "ctest" | "manual";
+  status: ProjectStatus;
+  weight: number;
+  weightedScore: number;
+  score?: number;
+  maxScore?: number;
+  cases?: ProjectCaseSummary[];
+  tests?: ProjectTestSummary[];
+  checklist?: string[];
+  buildFailed?: boolean;
+  buildPhase?: "configure" | "build";
+  diagnostic?: string;
+}
+
+export interface ProjectSubmissionSummary {
+  at: string;
+  target: "student" | "solution";
+  automatedScore: number;
+  automatedMax: number;
+  manualPending: number;
+  provisionalTotal: number;
+  total: number;
+  automatedFull: boolean;
+  internalError: boolean;
+  tasks: ProjectTaskSubmissionSummary[];
+}
+
+export interface ProjectProgress {
+  submissionCount: number;
+  automatedScore: number;
+  automatedMax: number;
+  manualPending: number;
+  provisionalTotal: number;
+  total: number;
+  automatedFull: boolean;
+  internalError: boolean;
+  lastSubmission?: ProjectSubmissionSummary;
+}
+
+export function summarizeProjectSubmission(result: ProjectScoreResult, at: string): ProjectSubmissionSummary {
+  return {
+    at,
+    target: result.target,
+    automatedScore: result.automatedScore,
+    automatedMax: result.automatedMax,
+    manualPending: result.manualPending,
+    provisionalTotal: result.provisionalTotal,
+    total: result.total,
+    automatedFull: result.automatedFull,
+    internalError: result.internalError,
+    tasks: result.tasks.map(summarizeTask),
+  };
+}
+
+export function projectProgressPassed(
+  progress: Pick<ProjectProgress, "automatedFull" | "manualPending" | "internalError">,
+): boolean {
+  return progress.automatedFull && progress.manualPending === 0 && !progress.internalError;
+}
+
+function summarizeTask(task: ProjectTaskResult): ProjectTaskSubmissionSummary {
+  const common = {
+    id: task.id,
+    kind: task.kind,
+    status: task.status,
+    weight: task.weight,
+    weightedScore: task.weightedScore,
+  };
+
+  if (task.kind === "manual") return { ...common, checklist: [...task.checklist] };
+  if (task.kind === "stdio") {
+    return {
+      ...common,
+      score: task.score,
+      maxScore: task.maxScore,
+      cases: task.judge.cases.map((testCase) => ({
+        id: testCase.id,
+        verdict: testCase.verdict,
+        points: testCase.points,
+        maxPoints: testCase.maxPoints,
+        durationMs: testCase.durationMs,
+      })),
+    };
+  }
+
+  return {
+    ...common,
+    score: task.score,
+    maxScore: task.maxScore,
+    tests: task.tests.map((test) => ({
+      name: test.name,
+      verdict: test.verdict,
+      points: test.points,
+      maxPoints: test.maxPoints,
+      durationMs: test.durationMs,
+    })),
+    buildFailed: task.build ? !task.build.ok : undefined,
+    buildPhase: task.build?.phase,
+  };
+}

--- a/tools/vscode-extension/src/stats.ts
+++ b/tools/vscode-extension/src/stats.ts
@@ -2,14 +2,14 @@
  * 统计聚合。全是纯函数,不 import vscode —— 这样能直接用 node:test 跑单测。
  *
  * countPassed 和 navFor 都因为宿主文件 import 了 vscode 而测不了,heatmap 的
- * 日期分桶和色阶分档是最容易出 off-by-one 的地方,必须能测。
+ * 日期分桶和色阶分档是最容易出 off-by-one 的地方,必须能测；章节统计也覆盖 Project。
  */
 
 export interface ActivityEvent {
   at: string;
   kind: "submit" | "pass";
   labName: string;
-  labType: "program" | "quiz";
+  labType: "program" | "quiz" | "project";
 }
 
 export interface Counters {
@@ -211,11 +211,11 @@ export function mockEvents(days: number, endDate: Date): ActivityEvent[] {
 
 /**
  * 章节分布。按 lab 的 type 去对应的进度表查 —— 和 countPassed 同一个道理,
- * 代码题和选择题的进度存在两张表里。
+ * 三种题型的进度存在不同的状态路径里。
  */
 export function buildChapterBars(
-  chapters: readonly { chapter: number; chapterTitle: string; labs: readonly { id?: string; name: string; type: "program" | "quiz" }[] }[],
-  isPassed: (name: string, type: "program" | "quiz") => boolean,
+  chapters: readonly { chapter: number; chapterTitle: string; labs: readonly { id?: string; name: string; type: "program" | "quiz" | "project" }[] }[],
+  isPassed: (name: string, type: "program" | "quiz" | "project") => boolean,
 ): ChapterBar[] {
   return chapters.map((chapter) => ({
     chapter: chapter.chapter,

--- a/tools/vscode-extension/src/statsPanel.ts
+++ b/tools/vscode-extension/src/statsPanel.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import * as vscode from "vscode";
 import type { Chapter } from "./labIndex";
+import { projectProgressPassed } from "./projectProgress";
 import type { ProgressTracker } from "./progress";
 import {
   buildChapterBars,
@@ -120,7 +121,11 @@ export class StatsPanel {
 
     const trend = buildTrend(events);
     const bars = buildChapterBars(chapters, (id, type) =>
-      type === "quiz" ? !!progress.getQuiz(id)?.passed : !!progress.get(id)?.passed,
+      type === "quiz"
+        ? !!progress.getQuiz(id)?.passed
+        : type === "project"
+          ? projectProgressPassed(progress.getProject(id) ?? { automatedFull: false, manualPending: 0, internalError: false })
+          : !!progress.get(id)?.passed,
     );
 
     const cspNonce = nonce();

--- a/tools/vscode-extension/src/tree.ts
+++ b/tools/vscode-extension/src/tree.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
 import { shortLabTitle } from "./labIdentity";
-import { discoverProgramLabs, type Chapter, type ProgramLab } from "./labIndex";
+import { discoverProgramLabs, type Chapter, type LabEntry, type ProjectLab } from "./labIndex";
 import { quizIconState } from "./quiz";
+import { projectProgressPassed, type ProjectProgress } from "./projectProgress";
 import type { LabProgress, ProgressTracker, QuizProgress } from "./progress";
 
 export class ChapterNode {
@@ -11,7 +12,7 @@ export class ChapterNode {
 
 export class LabNode {
   readonly kind = "lab" as const;
-  constructor(readonly lab: ProgramLab) {}
+  constructor(readonly lab: LabEntry) {}
 }
 
 export type TreeNode = ChapterNode | LabNode;
@@ -41,7 +42,7 @@ export class LabTreeProvider implements vscode.TreeDataProvider<TreeNode> {
     this.emitter.fire(undefined);
   }
 
-  allLabs(): ProgramLab[] {
+  allLabs(): LabEntry[] {
     return this.chapters.flatMap((chapter) => chapter.labs);
   }
 
@@ -50,7 +51,7 @@ export class LabTreeProvider implements vscode.TreeDataProvider<TreeNode> {
     return this.chapters;
   }
 
-  findLab(identifier: string): ProgramLab | undefined {
+  findLab(identifier: string): LabEntry | undefined {
     return this.allLabs().find(
       (lab) => lab.id === identifier || lab.name === identifier || lab.legacyNames.includes(identifier),
     );
@@ -83,14 +84,25 @@ export class LabTreeProvider implements vscode.TreeDataProvider<TreeNode> {
     const { lab } = node;
     const quizState = lab.type === "quiz" ? this.progress.getQuiz(lab.id) : undefined;
     const programState = lab.type === "program" ? this.progress.get(lab.id) : undefined;
+    const projectState = lab.type === "project" ? this.progress.getProject(lab.id) : undefined;
     const item = new vscode.TreeItem(`${lab.id} · ${shortLabTitle(lab.title)}`, vscode.TreeItemCollapsibleState.None);
 
-    item.description = lab.type === "quiz" ? describeQuizState(quizState) : describeState(programState);
-    item.iconPath = lab.type === "quiz" ? quizStateIcon(quizState) : stateIcon(programState);
-    item.tooltip = lab.type === "quiz"
-      ? buildQuizTooltip(lab, quizState)
-      : buildTooltip(lab, programState);
-    item.contextValue = "dsaMasteryLab";
+    if (lab.type === "quiz") {
+      item.description = describeQuizState(quizState);
+      item.iconPath = quizStateIcon(quizState);
+      item.tooltip = buildQuizTooltip(lab, quizState);
+      item.contextValue = "dsaMasteryLab";
+    } else if (lab.type === "project") {
+      item.description = describeProjectState(projectState);
+      item.iconPath = projectStateIcon(projectState);
+      item.tooltip = buildProjectTooltip(lab, projectState);
+      item.contextValue = "dsaMasteryProject";
+    } else {
+      item.description = describeState(programState);
+      item.iconPath = stateIcon(programState);
+      item.tooltip = buildTooltip(lab, programState);
+      item.contextValue = "dsaMasteryLab";
+    }
     item.command = {
       command: "dsaMastery.openLab",
       title: "打开题目",
@@ -124,7 +136,7 @@ function describeQuizState(state: QuizProgress | undefined): string {
   return state.passed ? `${correct}/${correct} · 已完成` : `${correct} 正确 · 已答 ${answered}`;
 }
 
-function buildQuizTooltip(lab: ProgramLab, state: QuizProgress | undefined): vscode.MarkdownString {
+function buildQuizTooltip(lab: Extract<LabEntry, { type: "quiz" }>, state: QuizProgress | undefined): vscode.MarkdownString {
   const tooltip = new vscode.MarkdownString(`**${lab.id} · ${lab.title}**\n\n${state?.passed ? "✅ 已完成" : "选择题"}\n\n已答：${state ? Object.keys(state.answers).length : 0}/${lab.quizQuestions?.length ?? 0}`);
   tooltip.supportThemeIcons = true;
   return tooltip;
@@ -150,7 +162,7 @@ function describeState(state: LabProgress | undefined): string {
   return `${state.bestScore}/${state.maxScore} · ${state.lastSubmission?.verdict ?? ""}`.trim();
 }
 
-function buildTooltip(lab: ProgramLab, state: LabProgress | undefined): vscode.MarkdownString {
+function buildTooltip(lab: Extract<LabEntry, { type: "program" }>, state: LabProgress | undefined): vscode.MarkdownString {
   const lines = [`**${lab.id} · ${lab.title}**`, ""];
   if (lab.description) lines.push(lab.description, "");
 
@@ -177,6 +189,52 @@ function buildTooltip(lab: ProgramLab, state: LabProgress | undefined): vscode.M
   const tooltip = new vscode.MarkdownString(lines.join("\n\n"));
   tooltip.supportThemeIcons = true;
   return tooltip;
+}
+
+function projectStateIcon(state: ProjectProgress | undefined): vscode.ThemeIcon {
+  if (state && projectProgressPassed(state)) {
+    return new vscode.ThemeIcon("pass-filled", new vscode.ThemeColor("testing.iconPassed"));
+  }
+  if (state && state.submissionCount > 0) {
+    return new vscode.ThemeIcon("symbol-misc", new vscode.ThemeColor("testing.iconQueued"));
+  }
+  return new vscode.ThemeIcon("symbol-misc");
+}
+
+function describeProjectState(state: ProjectProgress | undefined): string {
+  if (!state || state.submissionCount === 0) return "";
+  if (state.internalError) return "评测内部错误";
+  if (projectProgressPassed(state)) return `${formatScore(state.automatedScore)}/${formatScore(state.automatedMax)}`;
+  if (state.automatedFull && state.manualPending > 0) return "自动通过 · 待人工";
+  return `${formatScore(state.automatedScore)}/${formatScore(state.automatedMax)} · 待人工 ${formatScore(state.manualPending)}`;
+}
+
+function buildProjectTooltip(lab: ProjectLab, state: ProjectProgress | undefined): vscode.MarkdownString {
+  const lines = [`**${lab.id} · ${lab.title}**`, ""];
+  if (lab.description) lines.push(lab.description, "");
+  lines.push(`任务：${lab.tasks.length} 个`, `学生文件：${lab.studentFiles.length} 个`);
+
+  if (!state || state.submissionCount === 0) {
+    lines.push("尚未提交");
+  } else {
+    const status = state.internalError
+      ? "评测内部错误"
+      : projectProgressPassed(state)
+      ? "✅ 已完成"
+      : state.automatedFull && state.manualPending > 0
+        ? "自动通过 · 待人工"
+        : "自动部分未满";
+    lines.push(status, `自动得分：${formatScore(state.automatedScore)}/${formatScore(state.automatedMax)}`, `待人工：${formatScore(state.manualPending)}`, `提交次数：${state.submissionCount}`);
+    if (state.lastSubmission) lines.push(`最近一次：${new Date(state.lastSubmission.at).toLocaleString()}`);
+  }
+
+  const tooltip = new vscode.MarkdownString(lines.join("\n\n"));
+  tooltip.supportThemeIcons = true;
+  return tooltip;
+}
+
+function formatScore(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
 }
 
 function formatTime(iso: string): string {

--- a/tools/vscode-extension/test/lab-index.test.ts
+++ b/tools/vscode-extension/test/lab-index.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -123,6 +123,140 @@ test("discovers PR#122 category labs and keeps a legacy flat lab readable", asyn
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }
+});
+
+test("discovers project task metadata, cases, ctest names, and student files", async () => {
+  const { discoverProgramLabs } = await loadLabIndex();
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "dsa-lab-project-index-"));
+  try {
+    await writeLab(
+      repoRoot,
+      "labs/chapter-01/project/P-01-02-workload-analyzer",
+      { title: "Lab 01-P-02：工作负载分析器", description: "项目", order: 2, chapter: 1, chapterTitle: "线性表", labId: "01P02" },
+      {
+        schemaVersion: 1,
+        type: "project",
+        language: "cpp",
+        toolchain: { standard: "c++17", profile: "course-default" },
+        buildSystem: "cmake",
+        tasks: [
+          { id: "sequential", path: "tasks/sequential", weight: 30, kind: "stdio", dependsOn: [] },
+          { id: "linked", path: "tasks/linked", weight: 50, kind: "ctest", dependsOn: ["sequential"] },
+          { id: "report", path: "tasks/report", weight: 20, kind: "manual", dependsOn: ["linked"] },
+        ],
+      },
+      {
+        "tasks/sequential/task.json": JSON.stringify({
+          schemaVersion: 1,
+          id: "sequential",
+          kind: "stdio",
+          targets: { student: { sources: ["student/main.cpp"] } },
+          judge: { kind: "stdio", cases: "tests/cases.json" },
+        }),
+        "tasks/sequential/tests/cases.json": JSON.stringify([
+          { id: "small", input: "tests/small.in", expected: "tests/small.out", points: 40 },
+          { id: "large", input: "tests/large.in", expected: "tests/large.out", points: 60 },
+        ]),
+        "tasks/sequential/tests/small.in": "3\n",
+        "tasks/sequential/tests/small.out": "6\n",
+        "tasks/sequential/tests/large.in": "5\n",
+        "tasks/sequential/tests/large.out": "15\n",
+        "tasks/sequential/student/main.cpp": "int main() {}\n",
+        "tasks/linked/task.json": JSON.stringify({
+          schemaVersion: 1,
+          id: "linked",
+          kind: "ctest",
+          ctest: { tests: [{ name: "linked_basic", points: 50 }, { name: "linked_edge", points: 50 }] },
+        }),
+        "tasks/linked/student/linked.cpp": "// student implementation\n",
+        "tasks/report/task.json": JSON.stringify({
+          schemaVersion: 1,
+          id: "report",
+          kind: "manual",
+          checklist: ["复杂度分析", "实验报告"],
+        }),
+        "tasks/report/student/report.md": "# Report\n",
+      },
+    );
+
+    const labs = (await discoverProgramLabs(repoRoot)).flatMap((chapter) => chapter.labs);
+    const project = labs.find((lab) => lab.id === "01P02");
+
+    assert.ok(project);
+    assert.equal(project?.type, "project");
+    if (project?.type !== "project") return;
+
+    assert.equal(project.buildSystem, "cmake");
+    assert.deepEqual(project.tasks.map((task) => [task.id, task.kind, task.weight]), [
+      ["sequential", "stdio", 30],
+      ["linked", "ctest", 50],
+      ["report", "manual", 20],
+    ]);
+    assert.deepEqual(project.tasks[0]?.cases?.map((testCase) => testCase.id), ["small", "large"]);
+    assert.deepEqual(project.tasks[1]?.ctestTests?.map((testCase) => testCase.name), ["linked_basic", "linked_edge"]);
+    assert.deepEqual(project.tasks[2]?.checklist, ["复杂度分析", "实验报告"]);
+    assert.deepEqual(project.studentFiles.map((file) => file.relativePath).sort(), [
+      "tasks/linked/student/linked.cpp",
+      "tasks/report/student/report.md",
+      "tasks/sequential/student/main.cpp",
+    ]);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("does not follow a project student directory symlink", async () => {
+  if (process.platform === "win32") return;
+
+  const { discoverProgramLabs } = await loadLabIndex();
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "dsa-lab-project-symlink-"));
+  const outsideRoot = await mkdtemp(path.join(tmpdir(), "dsa-lab-project-outside-"));
+  try {
+    await writeLab(
+      repoRoot,
+      "labs/chapter-01/project/P-01-03-symlink",
+      { title: "Project", description: "安全边界", order: 3, chapter: 1, chapterTitle: "线性表", labId: "01P03" },
+      {
+        schemaVersion: 1,
+        type: "project",
+        language: "cpp",
+        toolchain: { standard: "c++17" },
+        buildSystem: "cmake",
+        tasks: [{ id: "review", path: "tasks/review", weight: 100, kind: "manual", dependsOn: [] }],
+      },
+      { "tasks/review/task.json": JSON.stringify({ schemaVersion: 1, kind: "manual", checklist: ["检查"] }) },
+    );
+    await writeFile(path.join(outsideRoot, "secret.cpp"), "should not be discovered\n", "utf8");
+    await symlink(outsideRoot, path.join(repoRoot, "labs/chapter-01/project/P-01-03-symlink/tasks/review/student"), "dir");
+
+    const labs = (await discoverProgramLabs(repoRoot)).flatMap((chapter) => chapter.labs);
+    const project = labs.find((lab) => lab.id === "01P03");
+
+    assert.ok(project);
+    assert.equal(project?.type, "project");
+    if (project?.type !== "project") return;
+    assert.deepEqual(project.studentFiles, []);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+    await rm(outsideRoot, { recursive: true, force: true });
+  }
+});
+
+test("discovers all real Project labs in the repository", async () => {
+  const { discoverProgramLabs } = await loadLabIndex();
+  const repoRoot = path.resolve(packageRoot, "../..");
+  const projects = (await discoverProgramLabs(repoRoot))
+    .flatMap((chapter) => chapter.labs)
+    .filter((lab) => lab.type === "project");
+
+  assert.deepEqual(projects.map((lab) => lab.id), ["01P01", "03P01", "03P02", "08P01", "09P01"]);
+  assert.deepEqual(projects.map((lab) => lab.relativePath), [
+    "labs/chapter-01/project/P-01-01-list-workload-analyzer",
+    "labs/chapter-03/project/P-03-01-string-match-engine",
+    "labs/chapter-03/project/P-03-02-sparse-matrix-library",
+    "labs/chapter-08/project/P-08-01-avl-tree-rotations",
+    "labs/chapter-09/project/P-09-01-hash-index-engine",
+  ]);
 });
 
 test("prefers the categorized lab when a transition checkout contains its old flat copy", async () => {

--- a/tools/vscode-extension/test/panel-ui.test.ts
+++ b/tools/vscode-extension/test/panel-ui.test.ts
@@ -72,3 +72,16 @@ test("program and quiz panels expose the stable Lab ID in their metadata", async
 
   assert.match(html, /题号 \$\{escapeHtml\(lab\.id\)\}/);
 });
+
+test("project panel exposes the task graph and manual pending state", async () => {
+  const html = await readPackageFile("src/panelHtml.ts");
+
+  assert.match(html, /renderProjectPanelHtml/);
+  assert.match(html, /project-task-card/);
+  assert.match(html, /PENDING/);
+  assert.match(html, /ctest/);
+  assert.match(html, /openProjectFile/);
+  assert.match(html, /project-score-grid/);
+  assert.match(html, /item\.comparison/);
+  assert.match(html, /item\.output/);
+});

--- a/tools/vscode-extension/test/project-progress.test.ts
+++ b/tools/vscode-extension/test/project-progress.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { projectProgressPassed, summarizeProjectSubmission } from "../src/projectProgress.ts";
+import type { ProjectScoreResult } from "../src/cli";
+
+test("project submission summaries preserve nested task results without long output", () => {
+  const result: ProjectScoreResult = {
+    target: "student",
+    tasks: [
+      {
+        id: "matcher",
+        kind: "stdio",
+        status: "AC",
+        score: 30,
+        maxScore: 30,
+        weight: 30,
+        weightedScore: 30,
+        judge: {
+          target: "student",
+          verdict: "AC",
+          score: 30,
+          maxScore: 30,
+          cases: [{ id: "sample", tags: [], verdict: "AC", points: 30, maxPoints: 30, durationMs: 4, stderr: "" }],
+          compilation: { ok: true, stdout: "", stderr: "" },
+        },
+      },
+      {
+        id: "report",
+        kind: "manual",
+        status: "PENDING",
+        weight: 20,
+        weightedScore: 0,
+        checklist: ["实验报告"],
+      },
+    ],
+    automatedScore: 30,
+    automatedMax: 30,
+    manualPending: 20,
+    provisionalTotal: 30,
+    total: 100,
+    automatedFull: true,
+    internalError: false,
+  };
+
+  const summary = summarizeProjectSubmission(result, "2026-09-02T00:00:00.000Z");
+
+  assert.equal(summary.tasks[0]?.cases?.[0]?.id, "sample");
+  assert.equal(summary.tasks[0]?.cases?.[0]?.verdict, "AC");
+  assert.deepEqual(summary.tasks[1]?.checklist, ["实验报告"]);
+  assert.equal("output" in (summary.tasks[0]?.cases?.[0] ?? {}), false);
+});
+
+test("automatic full score with manual weight remains pending instead of passed", () => {
+  assert.equal(projectProgressPassed({ automatedFull: true, manualPending: 20, internalError: false }), false);
+  assert.equal(projectProgressPassed({ automatedFull: true, manualPending: 0, internalError: false }), true);
+  assert.equal(projectProgressPassed({ automatedFull: true, manualPending: 0, internalError: true }), false);
+});

--- a/tools/vscode-extension/test/stats.test.ts
+++ b/tools/vscode-extension/test/stats.test.ts
@@ -17,7 +17,7 @@ function at(year: number, month: number, day: number, hour = 12): string {
   return new Date(year, month - 1, day, hour).toISOString();
 }
 
-function event(kind: "submit" | "pass", labName: string, iso: string, labType: "program" | "quiz" = "program"): ActivityEvent {
+function event(kind: "submit" | "pass", labName: string, iso: string, labType: "program" | "quiz" | "project" = "program"): ActivityEvent {
   return { at: iso, kind, labName, labType };
 }
 
@@ -172,4 +172,14 @@ test("chapter bars dispatch by lab type when checking passed", () => {
   const bars = buildChapterBars(chapters, (name, type) => type === "program" && name === "prog-1");
   assert.equal(bars[0].passed, 1);
   assert.equal(bars[0].total, 2);
+});
+
+test("chapter bars keep Project in the same type-aware completion flow", () => {
+  const chapters = [{
+    chapter: 3,
+    chapterTitle: "字符串",
+    labs: [{ name: "project-1", type: "project" as const }],
+  }];
+  const bars = buildChapterBars(chapters, (name, type) => type === "project" && name === "project-1");
+  assert.deepEqual(bars[0], { chapter: 3, chapterTitle: "字符串", passed: 1, total: 1 });
 });


### PR DESCRIPTION
## Summary

- Support discovering and displaying Project Labs with task metadata, student-file entry points, dependencies, weights, and README content.
- Reuse the existing Project JSON judging protocol for stdio and CTest tasks; keep manual tasks as `PENDING` with checklist and separate progress semantics.
- Preserve Program/Quiz compatibility, add Project progress and nested result rendering, update docs/release metadata, and bump the extension to `0.1.12`.

## Validation

- Extension tests: 41/41 passed
- TypeScript typecheck passed
- esbuild bundle passed
- Repository `pnpm test` passed
- Project CLI stdio JSON path verified; full CMake Golden execution remains environment-limited because this machine has no `cmake`.

## Release

The `ext-v0.1.12` GitHub release will be published as a pre-release with the generated `.vsix` attached.