### PR TITLE
fix(bootstrap): 修复 Windows 一键安装脚本的多个问题

### DIFF
--- a/scripts/bootstrap/bootstrap-windows.ps1
+++ b/scripts/bootstrap/bootstrap-windows.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param(
     [ValidateSet("runtime", "basic", "full")]
     [string]$Profile,
@@ -16,11 +16,24 @@ param(
     [string[]]$RemainingArgs
 )
 
+# Force UTF-8 output encoding for this console session
+try {
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+    [Console]::InputEncoding = [System.Text.Encoding]::UTF8
+    $OutputEncoding = [System.Text.Encoding]::UTF8
+} catch { }
+
 $ErrorActionPreference = "Stop"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $LocalSetup = Join-Path $ScriptDir "setup.mjs"
 $LocalRepoRoot = (Resolve-Path (Join-Path $ScriptDir "..\..")).Path
 $BuildToolsId = "Microsoft.VisualStudio.2022.BuildTools"
+
+function Test-AdminRights {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
 
 function Test-CommandAvailable {
     param([Parameter(Mandatory = $true)][string]$Name)
@@ -35,16 +48,45 @@ function Refresh-ProcessPath {
     }
 }
 
+function Update-WingetSource {
+    if (-not (Test-CommandAvailable "winget")) { return }
+    try {
+        & winget source update --accept-source-agreements 2>&1 | Out-Null
+    } catch {
+        Write-Warning "winget source update failed, continuing with cached index"
+    }
+}
+
 function Install-WingetPackage {
-    param([Parameter(Mandatory = $true)][string]$Id, [string[]]$ExtraArguments = @())
+    param(
+        [Parameter(Mandatory = $true)][string]$Id,
+        [string[]]$ExtraArguments = @(),
+        [int]$MaxRetries = 2
+    )
     if (-not (Test-CommandAvailable "winget")) {
-        throw "未找到 winget，无法自动安装 $Id；请按 docs/WINDOWS_STUDENT_SETUP_GUIDE.md 手工安装。"
+        throw "winget not found. Please install App Installer from Microsoft Store, then retry."
     }
-    & winget install --id $Id --exact --source winget --accept-source-agreements --accept-package-agreements @ExtraArguments
-    if ($LASTEXITCODE -ne 0) {
-        throw "winget 安装失败：$Id（exit $LASTEXITCODE）"
+    Update-WingetSource
+    $attempt = 0
+    while ($attempt -lt $MaxRetries) {
+        $attempt++
+        & winget install --id $Id --exact --source winget --accept-source-agreements --accept-package-agreements @ExtraArguments
+        if ($LASTEXITCODE -eq 0) {
+            Refresh-ProcessPath
+            return
+        }
+        if ($LASTEXITCODE -eq -1978335189) {
+            Write-Host "Package already installed ($Id), skipping." -ForegroundColor Yellow
+            Refresh-ProcessPath
+            return
+        }
+        Write-Warning "winget install attempt $attempt/$MaxRetries failed for $Id (exit $LASTEXITCODE)"
+        if ($attempt -lt $MaxRetries) {
+            Update-WingetSource
+            Start-Sleep -Seconds 3
+        }
     }
-    Refresh-ProcessPath
+    throw "winget install failed after $MaxRetries attempts: $Id (exit $LASTEXITCODE)"
 }
 
 function Node-IsReady {
@@ -60,14 +102,14 @@ function Node-IsReady {
 
 function Ensure-Node {
     if (Node-IsReady) { return }
-    if ($CheckOnly) { throw "check-only：Node.js 不满足 >= 22.13.0；未执行安装。" }
+    if ($CheckOnly) { throw "check-only: Node.js >= 22.13.0 not satisfied; install skipped." }
     Install-WingetPackage "OpenJS.NodeJS.LTS"
-    if (-not (Node-IsReady)) { throw "Node.js 安装后仍未满足 >= 22.13.0；请打开新终端后重试。" }
+    if (-not (Node-IsReady)) { throw "Node.js install completed but version still < 22.13.0; open a new terminal and retry." }
 }
 
 function Ensure-Git {
     if (Test-CommandAvailable "git") { return }
-    if ($CheckOnly) { throw "check-only：未找到 Git；未执行安装。" }
+    if ($CheckOnly) { throw "check-only: Git not found; install skipped." }
     Install-WingetPackage "Git.Git"
 }
 
@@ -78,6 +120,11 @@ function Test-ValidRepository {
         (Test-Path (Join-Path $Path "labs") -PathType Container) -and
         (Test-Path (Join-Path $Path "tools\lab\cli.mjs") -PathType Leaf) -and
         (Test-Path (Join-Path $Path "scripts\bootstrap\setup.mjs") -PathType Leaf)
+}
+
+# Warn about admin rights (Build Tools / VS Code may need elevation)
+if (-not (Test-AdminRights) -and -not $CheckOnly) {
+    Write-Host "Note: running without administrator privileges. Some installers (VS Build Tools) may request elevation." -ForegroundColor Yellow
 }
 
 if (-not $RepoDir) {
@@ -95,14 +142,14 @@ Ensure-Git
 if (-not (Test-Path $LocalSetup -PathType Leaf)) {
     if ($CheckOnly) {
         if (-not (Test-ValidRepository $RepoDir)) {
-            throw "从仓库外执行 -CheckOnly 时，必须提供已经存在的有效仓库：$RepoDir"
+            throw "Running -CheckOnly from outside the repo requires an existing valid repo: $RepoDir"
         }
     } else {
         if (Test-Path $RepoDir) {
             if (-not (Test-ValidRepository $RepoDir)) {
                 $entries = @(Get-ChildItem -LiteralPath $RepoDir -Force)
                 if ($entries.Count -gt 0) {
-                    throw "目标目录不为空且不是 DSA Mastery 仓库，不会覆盖：$RepoDir"
+                    throw "Target directory is non-empty and not a DSA Mastery repo, will not overwrite: $RepoDir"
                 }
             }
         } else {
@@ -110,13 +157,13 @@ if (-not (Test-Path $LocalSetup -PathType Leaf)) {
         }
         if (-not (Test-ValidRepository $RepoDir)) {
             & git clone $RepoUrl $RepoDir
-            if ($LASTEXITCODE -ne 0) { throw "git clone 失败：$RepoUrl" }
+            if ($LASTEXITCODE -ne 0) { throw "git clone failed: $RepoUrl" }
         }
     }
 }
 
 $SetupPath = if (Test-Path $LocalSetup -PathType Leaf) { $LocalSetup } else { Join-Path $RepoDir "scripts\bootstrap\setup.mjs" }
-if (-not (Test-Path $SetupPath -PathType Leaf)) { throw "找不到 DSA Mastery setup.mjs：$SetupPath" }
+if (-not (Test-Path $SetupPath -PathType Leaf)) { throw "Cannot find DSA Mastery setup.mjs: $SetupPath" }
 
 $Forwarded = @()
 if ($Profile) { $Forwarded += @("--profile", $Profile) }

--- a/scripts/bootstrap/checks.mjs
+++ b/scripts/bootstrap/checks.mjs
@@ -75,11 +75,20 @@ async function probeTool(name, command, args, minimum, options = {}) {
 export async function inspectHost({ platform = process.platform, architecture = process.arch, env = process.env, runner = runCommand, nodeCommand = process.execPath } = {}) {
   let msvcEnvironment;
   let msvcError;
+  let msvcFallbackPath;
   if (platform === "win32") {
     try {
       msvcEnvironment = await createMsvcEnvironment({ platform, env, runner });
     } catch (error) {
       msvcError = error;
+      // Fallback: probe vswhere directly even when VsDevCmd init fails
+      try {
+        const { findVisualStudioInstallation } = await import("../../tools/lab/toolchain.mjs");
+        const found = await findVisualStudioInstallation({ platform, env, runner });
+        if (found?.installationPath) {
+          msvcFallbackPath = found.installationPath;
+        }
+      } catch { /* ignore fallback probe errors */ }
     }
   }
   const tools = await Promise.all([
@@ -110,10 +119,11 @@ export async function inspectHost({ platform = process.platform, architecture = 
     runtimeReady: Boolean(node?.meetsMinimum && pnpm?.meetsMinimum),
     msvc: {
       initialized: Boolean(msvcEnvironment),
-      installationPath: msvcEnvironment?.installationPath,
+      installationPath: msvcEnvironment?.installationPath ?? msvcFallbackPath,
       developerCommand: msvcEnvironment?.developerCommand,
       environment: msvcEnvironment?.env,
       error: msvcError?.message,
+      fallbackDetected: Boolean(msvcFallbackPath),
     },
   };
 }

--- a/scripts/bootstrap/commands.mjs
+++ b/scripts/bootstrap/commands.mjs
@@ -1,4 +1,53 @@
-import { spawn } from "node:child_process";
+import { spawn, execFileSync } from "node:child_process";
+import path from "node:path";
+
+const WINDOWS_SCRIPT_EXT = /\.(cmd|bat|com)$/i;
+
+function resolveWindowsCommand(command, env) {
+  if (path.isAbsolute(command)) return command;
+  if (/\.(exe|cmd|bat|com|ps1|msi|vbs|js|wsh)$/i.test(command)) return command;
+  try {
+    const found = execFileSync("where.exe", [command], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      env: env ?? process.env,
+    });
+    const candidates = found.split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+    // Prefer Windows-executable extensions over extension-less shell scripts
+    const withExt = candidates.find((c) => /\.(exe|cmd|bat|com)$/i.test(c));
+    if (withExt) return withExt;
+    if (candidates[0]) return candidates[0];
+  } catch {
+    /* where.exe failed; fall through and let spawn report the error */
+  }
+  return command;
+}
+
+function buildSpawnTarget(command, args, env) {
+  if (process.platform !== "win32") return { command, args };
+  const resolved = resolveWindowsCommand(command, env);
+  if (WINDOWS_SCRIPT_EXT.test(resolved)) {
+    // Quote the script path, then quote any args containing spaces,
+    // and pass the whole line as a single /c argument so cmd.exe
+    // preserves spaces inside the path correctly.
+    const quotedCommand = `"${resolved}"`;
+    const argString = args.map((a) => {
+      const value = String(a);
+      return /[\s"]/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value;
+    }).join(" ");
+    const fullCommand = argString ? `${quotedCommand} ${argString}` : quotedCommand;
+    return {
+      command: "cmd.exe",
+      args: ["/c", fullCommand],
+      windowsVerbatimArguments: true,
+    };
+  }
+  if (/cmd(?:\.exe)?$/i.test(resolved)) {
+    return { command: resolved, args, windowsVerbatimArguments: true };
+  }
+  return { command: resolved, args };
+}
 
 export function runCommand(command, args = [], options = {}) {
   const {
@@ -10,15 +59,17 @@ export function runCommand(command, args = [], options = {}) {
     inherit = false,
   } = options;
   const childEnvironment = env === undefined ? process.env : { ...process.env, ...env };
+  const target = buildSpawnTarget(command, args, childEnvironment);
 
   if (inherit) {
     return new Promise((resolve, reject) => {
       const started = performance.now();
-      const child = spawn(command, args, {
+      const child = spawn(target.command, target.args, {
         cwd,
         env: childEnvironment,
         shell: false,
         windowsHide: true,
+        windowsVerbatimArguments: target.windowsVerbatimArguments,
         stdio: "inherit",
       });
       child.once("error", reject);
@@ -33,11 +84,12 @@ export function runCommand(command, args = [], options = {}) {
   return new Promise((resolve) => {
     const started = performance.now();
     const limitBytes = outputLimitKb * 1024;
-    const child = spawn(command, args, {
+    const child = spawn(target.command, target.args, {
       cwd,
       env: childEnvironment,
       shell: false,
       windowsHide: true,
+      windowsVerbatimArguments: target.windowsVerbatimArguments,
       stdio: ["pipe", "pipe", "pipe"],
     });
     const stdout = [];

--- a/scripts/bootstrap/setup.mjs
+++ b/scripts/bootstrap/setup.mjs
@@ -159,6 +159,96 @@ function wingetInstall(id, extra = []) {
   };
 }
 
+const VS_BUILDTOOLS_INSTALLER_URL = "https://aka.ms/vs/17/release/vs_buildtools.exe";
+const VC_TOOLS_COMPONENT = "Microsoft.VisualStudio.Component.VC.Tools.x86.x64";
+
+async function findVisualStudioViaVsWhere(context) {
+  const candidates = [];
+  if (context.env["ProgramFiles(x86)"]) {
+    candidates.push(path.join(context.env["ProgramFiles(x86)"], "Microsoft Visual Studio", "Installer", "vswhere.exe"));
+  }
+  candidates.push("vswhere.exe");
+  for (const command of [...new Set(candidates)]) {
+    const result = await runWithRunner(context, command, [
+      "-latest",
+      "-products",
+      "*",
+      "-requires",
+      VC_TOOLS_COMPONENT,
+      "-property",
+      "installationPath",
+    ], { timeoutMs: 10_000, outputLimitKb: 256 });
+    if (!resultFailed(result)) {
+      const installationPath = resultOutput(result).split(/\r?\n/).find(Boolean)?.trim();
+      if (installationPath) return { installationPath, vswhere: command };
+    }
+  }
+  return undefined;
+}
+
+async function downloadFileWithPowershell(context, url, destination) {
+  const result = await runWithRunner(context, "powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '${url}' -OutFile '${destination}' -UseBasicParsing`,
+  ], { timeoutMs: 10 * 60_000, outputLimitKb: 4096 });
+  if (resultFailed(result)) {
+    throw setupError("INSTALLER_FAILED", `下载失败：${url}`, { command: "powershell.exe", result });
+  }
+  return destination;
+}
+
+async function installVisualStudioBuildTools(context) {
+  const existing = await findVisualStudioViaVsWhere(context);
+  if (existing) {
+    context.ui.update("toolchain", "running", `检测到已安装 Visual Studio C++ 工具：${existing.installationPath}`);
+    return { skipped: true, reason: "already-installed", installationPath: existing.installationPath };
+  }
+
+  if (context.packageManager?.kind === "winget") {
+    const install = wingetInstall("Microsoft.VisualStudio.2022.BuildTools", [
+      "--wait",
+      "--override",
+      "--passive --norestart --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended",
+    ]);
+    try {
+      context.ui.update("toolchain", "running", "通过 winget 安装 Visual Studio C++ Build Tools");
+      await runExternal(context, install.command, install.args, {
+        inherit: true,
+        timeoutMs: 45 * 60_000,
+        errorMessage: "winget 安装 Visual Studio C++ Build Tools 失败",
+      });
+      return { method: "winget" };
+    } catch (wingetError) {
+      context.ui.update("toolchain", "running", "winget 安装未成功，回退到官方安装程序");
+    }
+  }
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dsa-mastery-vs-"));
+  const installer = path.join(tempDir, "vs_buildtools.exe");
+  try {
+    context.ui.update("toolchain", "running", "下载 Visual Studio Build Tools 官方安装程序");
+    await downloadFileWithPowershell(context, VS_BUILDTOOLS_INSTALLER_URL, installer);
+    context.ui.update("toolchain", "running", "运行官方安装程序（可能需要 10-30 分钟）");
+    await runExternal(context, installer, [
+      "--wait",
+      "--passive",
+      "--norestart",
+      "--add",
+      "Microsoft.VisualStudio.Workload.VCTools",
+      "--includeRecommended",
+    ], {
+      inherit: true,
+      timeoutMs: 90 * 60_000,
+      errorMessage: "官方安装程序安装 Visual Studio C++ Build Tools 失败",
+    });
+    return { method: "official-installer" };
+  } finally {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
 export function planToolchainInstall(profile, host = {}) {
   const requirement = profileRequirements(profile);
   const plan = [];
@@ -180,10 +270,12 @@ export function planToolchainInstall(profile, host = {}) {
   if (platform === "win32") {
     if (missing("Git")) add("git", "安装 Git", ...Object.values(wingetInstall("Git.Git")));
     if (missing("Node.js")) add("node", "安装 Node.js LTS", ...Object.values(wingetInstall("OpenJS.NodeJS.LTS")));
-    if (requirement.requiresCompiler && !hasTool(host, "MSVC")) {
+    const hasAnyCompiler = hasTool(host, "MSVC") || hasTool(host, "GCC") || hasTool(host, "Clang");
+    if (requirement.requiresCompiler && !hasAnyCompiler) {
       add("msvc", "安装 Visual Studio C++ Build Tools", ...Object.values(wingetInstall("Microsoft.VisualStudio.2022.BuildTools", [
+        "--wait",
         "--override",
-        "--wait --passive --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended",
+        "--passive --norestart --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended",
       ])));
     }
     if (requirement.requiresCmake && missing("CMake")) add("cmake", "安装 CMake", ...Object.values(wingetInstall("Kitware.CMake")));
@@ -378,13 +470,17 @@ async function installSystemTools(context) {
       await runExternal(context, action.command, action.args, { inherit: true, errorCode: "NEEDS_USER_ACTION" });
       throw setupError("NEEDS_USER_ACTION", "Xcode Command Line Tools 安装窗口已打开；请完成安装后重新运行此脚本。", { restartRequired: true });
     }
+    if (action.id === "msvc" && context.platform === "win32") {
+      await installVisualStudioBuildTools(context);
+      context.ui.update("toolchain", "running", "Visual Studio 安装完成，准备捕获开发环境");
+      continue;
+    }
     const command = action.command === "brew" ? context.packageManager.command : action.command;
     await runExternal(context, command, action.args, {
       inherit: true,
       timeoutMs: 20 * 60_000,
       errorMessage: `${action.description}失败：${commandText(command, action.args)}`,
     });
-    if (action.id === "msvc") context.ui.update("toolchain", "running", "Visual Studio 安装完成，准备捕获开发环境");
   }
   await refreshPlatformEnvironment(context);
   context.nodeCommand = await resolveExecutable(context, "node");
@@ -529,8 +625,52 @@ async function runSmoke(context) {
   return results;
 }
 
+async function detectVSCode(context) {
+  const direct = await commandAvailable(context, "code", ["--version"]);
+  if (direct) return { found: true, inPath: true };
+
+  if (context.platform !== "win32") return { found: false };
+
+  // Try where.exe against the live process PATH (may have entries lost by refresh)
+  try {
+    const { execFileSync } = await import("node:child_process");
+    const found = execFileSync("where.exe", ["code"], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      env: process.env,
+    });
+    const candidates = found.split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+    const codeCmd = candidates.find((p) => /\.cmd$/i.test(p)) || candidates.find((p) => /\.exe$/i.test(p)) || candidates[0];
+    if (codeCmd && (await pathExists(codeCmd))) {
+      const binDir = path.dirname(codeCmd);
+      context.env.PATH = prependPath(context.env.PATH, [binDir], ";");
+      const retry = await commandAvailable(context, "code", ["--version"]);
+      if (retry) return { found: true, inPath: false, path: binDir };
+    }
+  } catch { /* where.exe not available or code not found */ }
+
+  // Scan standard install directories
+  const standardDirs = [];
+  if (context.env.LOCALAPPDATA) standardDirs.push(path.join(context.env.LOCALAPPDATA, "Programs", "Microsoft VS Code", "bin"));
+  if (context.env["ProgramFiles"]) standardDirs.push(path.join(context.env["ProgramFiles"], "Microsoft VS Code", "bin"));
+  if (context.env["ProgramFiles(x86)"]) standardDirs.push(path.join(context.env["ProgramFiles(x86)"], "Microsoft VS Code", "bin"));
+  for (const binDir of standardDirs) {
+    if (await pathExists(path.join(binDir, "code.cmd"))) {
+      context.env.PATH = prependPath(context.env.PATH, [binDir], ";");
+      const retry = await commandAvailable(context, "code", ["--version"]);
+      if (retry) return { found: true, inPath: false, path: binDir };
+    }
+  }
+  return { found: false };
+}
+
 async function installIde(context) {
   if (context.options.skipVscode || !context.options.installVscode) return { status: "skipped", message: "未选择 VS Code" };
+  const detected = await detectVSCode(context);
+  if (detected.found && !detected.inPath) {
+    context.ui.update("ide", "running", `检测到已安装 VS Code：${detected.path}`);
+  }
   let code = await commandAvailable(context, "code", ["--version"]);
   if (!code) {
     if (context.platform === "darwin") {
@@ -664,6 +804,10 @@ function normalizeError(rawError) {
 }
 
 export async function runSetup(argv = [], dependencies = {}) {
+  if (process.platform === "win32") {
+    try { process.stdout.setEncoding("utf8"); } catch {}
+    try { process.stderr.setEncoding("utf8"); } catch {}
+  }
   let options;
   try {
     options = parseSetupArgs(argv);
@@ -816,12 +960,35 @@ export async function runSetup(argv = [], dependencies = {}) {
   return { exitCode: report.exitCode, report, summary, uiMode: context.ui.mode };
 }
 
+function printSuccessBanner() {
+  const reset = "\x1b[0m";
+  const bold = "\x1b[1m";
+  // Gradient: blue -> cyan -> green
+  const colors = ["\x1b[38;5;27m", "\x1b[38;5;33m", "\x1b[38;5;39m", "\x1b[38;5;42m", "\x1b[38;5;46m"];
+  const lines = [
+    "  ____  ____   _    __  __           __  __           _             ",
+    " |  _ \\/ ___| / \\  |  \\/  |         |  \\/  | __ _ ___| |_ ___ _ __  ",
+    " | | | \\___ \\/ _ \\ | |\\/| |  _____  | |\\/| |/ _` / __| __/ _ \\ '__| ",
+    " | |_| |___) / ___ \\| |  | | |_____| | |  | | (_| \\__ \\ ||  __/ |    ",
+    " |____/|____/_/   \\_\\_|  |_|         |_|  |_|\\__,_|___/\\__\\___|_|    ",
+  ];
+  let output = "\n";
+  lines.forEach((line, i) => {
+    output += colors[i % colors.length] + bold + line + reset + "\n";
+  });
+  output += "\n";
+  return output;
+}
+
 async function main() {
   const result = await runSetup(process.argv.slice(2));
   if (result.report.help) console.log(result.report.help);
   else if (result.report.command === "setup" && !result.report.error && process.argv.includes("--json")) console.log(JSON.stringify(result.report, null, 2));
   else if (process.argv.includes("--json")) console.log(JSON.stringify(result.report, null, 2));
   else if (result.summary && result.uiMode !== "tui") console.log(result.summary);
+  if (result.report.ok && !process.argv.includes("--json") && result.uiMode !== "tui") {
+    process.stdout.write(printSuccessBanner());
+  }
   process.exitCode = result.exitCode;
 }
 

--- a/scripts/bootstrap/setup.mjs
+++ b/scripts/bootstrap/setup.mjs
@@ -220,7 +220,7 @@ async function installVisualStudioBuildTools(context) {
         errorMessage: "winget 安装 Visual Studio C++ Build Tools 失败",
       });
       return { method: "winget" };
-    } catch (wingetError) {
+    } catch {
       context.ui.update("toolchain", "running", "winget 安装未成功，回退到官方安装程序");
     }
   }
@@ -805,8 +805,8 @@ function normalizeError(rawError) {
 
 export async function runSetup(argv = [], dependencies = {}) {
   if (process.platform === "win32") {
-    try { process.stdout.setEncoding("utf8"); } catch {}
-    try { process.stderr.setEncoding("utf8"); } catch {}
+    try { process.stdout.setEncoding("utf8"); } catch { /* non-TTY environments may throw */ }
+    try { process.stderr.setEncoding("utf8"); } catch { /* non-TTY environments may throw */ }
   }
   let options;
   try {

--- a/tools/lab/process.mjs
+++ b/tools/lab/process.mjs
@@ -1,4 +1,52 @@
-import { spawn } from "node:child_process";
+import { spawn, execFileSync } from "node:child_process";
+import path from "node:path";
+
+const WINDOWS_SCRIPT_EXT = /\.(cmd|bat|com)$/i;
+
+function resolveWindowsCommand(command, env) {
+  if (path.isAbsolute(command)) return command;
+  if (/\.(exe|cmd|bat|com|ps1|msi|vbs|js|wsh)$/i.test(command)) return command;
+  try {
+    const found = execFileSync("where.exe", [command], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      env: env ?? process.env,
+    });
+    const candidates = found.split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+    const withExt = candidates.find((c) => /\.(exe|cmd|bat|com)$/i.test(c));
+    if (withExt) return withExt;
+    if (candidates[0]) return candidates[0];
+  } catch {
+    /* where.exe failed; fall through and let spawn report the error */
+  }
+  return command;
+}
+
+function buildSpawnTarget(command, args, env) {
+  if (process.platform !== "win32") return { command, args };
+  const resolved = resolveWindowsCommand(command, env);
+  if (WINDOWS_SCRIPT_EXT.test(resolved)) {
+    // Quote the script path, then quote any args containing spaces,
+    // and pass the whole line as a single /c argument so cmd.exe
+    // preserves spaces inside the path correctly.
+    const quotedCommand = `"${resolved}"`;
+    const argString = args.map((a) => {
+      const value = String(a);
+      return /[\s"]/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value;
+    }).join(" ");
+    const fullCommand = argString ? `${quotedCommand} ${argString}` : quotedCommand;
+    return {
+      command: "cmd.exe",
+      args: ["/c", fullCommand],
+      windowsVerbatimArguments: true,
+    };
+  }
+  if (/cmd(?:\.exe)?$/i.test(resolved)) {
+    return { command: resolved, args, windowsVerbatimArguments: true };
+  }
+  return { command: resolved, args };
+}
 
 export function runProcess(command, args, options = {}) {
   const {
@@ -10,10 +58,19 @@ export function runProcess(command, args, options = {}) {
     env,
   } = options;
   const childEnvironment = env === undefined ? process.env : { ...process.env, ...env };
+  const target = buildSpawnTarget(command, args, childEnvironment);
+
   if (inherit) {
     return new Promise((resolve, reject) => {
       const started = performance.now();
-      const child = spawn(command, args, { cwd, env: childEnvironment, shell: false, windowsHide: true, stdio: "inherit" });
+      const child = spawn(target.command, target.args, {
+        cwd,
+        env: childEnvironment,
+        shell: false,
+        windowsHide: true,
+        windowsVerbatimArguments: target.windowsVerbatimArguments,
+        stdio: "inherit",
+      });
       child.once("error", reject);
       child.once("close", (code, signal) => resolve({ code, signal, durationMs: performance.now() - started }));
     });
@@ -21,7 +78,14 @@ export function runProcess(command, args, options = {}) {
   return new Promise((resolve) => {
     const started = performance.now();
     const limitBytes = outputKb * 1024;
-    const child = spawn(command, args, { cwd, env: childEnvironment, shell: false, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] });
+    const child = spawn(target.command, target.args, {
+      cwd,
+      env: childEnvironment,
+      shell: false,
+      windowsHide: true,
+      windowsVerbatimArguments: target.windowsVerbatimArguments,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
     const stdout = [];
     const stderr = [];
     let stdoutBytes = 0;

--- a/tools/lab/toolchain.mjs
+++ b/tools/lab/toolchain.mjs
@@ -73,10 +73,10 @@ export async function createMsvcEnvironment({ platform = process.platform, env =
     );
   }
   const developerCommand = path.win32.join(installation.installationPath, "Common7", "Tools", "VsDevCmd.bat");
-  const commandLine = `call "${developerCommand}" -arch=x64 >nul && set`;
+  const commandLine = `call "${developerCommand}" -arch=x64 >nul 2>&1 && set`;
   const result = await runner("cmd.exe", ["/d", "/s", "/c", commandLine], {
     env,
-    timeMs: 30_000,
+    timeMs: 60_000,
     outputKb: 4096,
   });
   if (result?.spawnError || result?.code !== 0) {


### PR DESCRIPTION
## 修复内容

修复 Windows 一键安装脚本（`bootstrap-windows.ps1` + `setup.mjs`）的多个关键问题，实现真正的一键式安装。

### 核心修复

1. **VS Build Tools 重复安装**：原脚本只认 MSVC，系统已有 MinGW GCC/Clang 时仍强行重装。改为 `hasAnyCompiler = MSVC || GCC || Clang`，有任一可用编译器即跳过。
2. **winget 参数错误**：`--wait` 被错误地放进 `--override` 字符串，修正为 winget 独立参数。
3. **winget 失败无回退**：新增官方 `vs_buildtools.exe` 直连下载安装作为兜底，winget 源不可用时自动切换。
4. **Windows `.CMD`/`.BAT` 无法执行**：`spawn(shell:false)` 在 Windows 上不能直接执行批处理文件，新增 `cmd.exe /c` 包装层。
5. **`where.exe` 返回无扩展名脚本**：优先选择带 `.exe/.cmd/.bat` 扩展名的结果，避免选中 Bash 脚本导致 ENOENT。
6. **带空格路径引号截断**：`cmd.exe /s /c` 对含空格路径处理有误，改为 `/c` + 整行命令字符串，`C:\Program Files\...` 和自定义路径均正常。
7. **VS Code 检测不到**：新增三级检测（直接命令 → where.exe 扫描 → 标准目录扫描），自定义安装路径也能识别并自动加回 PATH。
8. **中文乱码**：ps1 保存为 UTF-8 with BOM，Node.js 设置 stdout/stderr 编码。

### 增强功能

- winget 源自动更新 + 安装失败重试（2次）
- 已安装包检测（winget exit -1978335189 视为已安装）
- 管理员权限提示
- VsDevCmd.bat 超时 30s → 60s，stderr 重定向抑制噪音
- 安装全部成功后显示渐变色（蓝→青→绿）`DSA-Mastery` ASCII banner

### 修改文件

| 文件 | 说明 |
|---|---|
| `scripts/bootstrap/setup.mjs` | 核心安装逻辑、VS Code 检测、banner |
| `scripts/bootstrap/commands.mjs` | Windows 命令解析与执行 |
| `scripts/bootstrap/bootstrap-windows.ps1` | 入口脚本、编码、winget 重试 |
| `scripts/bootstrap/checks.mjs` | MSVC 检测回退 |
| `tools/lab/process.mjs` | CLI 工具命令执行（同步修复） |
| `tools/lab/toolchain.mjs` | VsDevCmd 超时与重定向 |

### 验证

full profile 一键安装 6/6 阶段全部通过：preflight ✓ toolchain ✓ repository ✓ dependencies ✓ ide ✓ smoke ✓