### PR TITLE
docs(ch5): 为「树的应用」五节代码添加详细注解，拓展部分内容，修复 01 页构建错误

### DIFF
--- a/content/chapter-05-tree-applications/01-binary-search-tree-and-avl.md
+++ b/content/chapter-05-tree-applications/01-binary-search-tree-and-avl.md
@@ -4,8 +4,8 @@ description: "掌握二叉搜索树的查找、插入与删除，并用 AVL 旋�
 order: 1
 chapter: 5
 chapterTitle: "树的应用"
-updated: "2026-08-24"
-contributors: ["Azen"]
+updated: "2026-09-10"
+contributors: ["CzjLUCK&Azen"]
 status: "review"
 ---
 
@@ -89,22 +89,27 @@ struct Node {
     Node* right{};
 };
 
+// 查找：沿 BST 比较规则向下走，找到返回节点指针，找不到返回 nullptr
 Node* search(Node* root, int key) {
     while (root != nullptr && root->key != key) {
+        // 当前节点不是目标，根据大小关系选择左/右子树继续
         root = key < root->key ? root->left : root->right;
     }
-    return root;
+    return root;  // 命中返回该节点，走到空链接则查找失败
 }
 
+// 插入：先走查找路径，在第一个空链接处创建新节点
+// 使用 Node** 统一处理"接在根上还是接在孩子上"
 bool insert(Node*& root, int key) {
-    Node** link = &root;
+    Node** link = &root;           // link 始终指向"下一个该被填充的指针槽位"
     while (*link != nullptr) {
         if (key == (*link)->key) {
-            return false;  // 本实现拒绝重复键
+            return false;          // 本实现拒绝重复键
         }
+        // 决定往左子树还是右子树走，link 更新为对应指针的地址
         link = key < (*link)->key ? &(*link)->left : &(*link)->right;
     }
-    *link = new Node{key};
+    *link = new Node{key};         // 在空链接处接入新节点
     return true;
 }
 ```
@@ -138,7 +143,62 @@ bool insert(Node*& root, int key) {
 删除双孩子节点时只把前驱或后继的“记录内容”移到目标位置，再在原位置删除替身。直接把替身节点指针覆盖到目标位置，若没有同时重接原左右子树，很容易丢失节点、制造重复所有权或破坏链接。
 :::
 
-## 5.1.2 二叉搜索树的实现、复杂度与退化【C/C++】
+### C++：用唯一所有权实现删除
+
+下面的删除函数使用 `std::unique_ptr` 表达“父节点独占孩子”的所有权。返回值始终是删除后子树的新根，因此叶删除、单孩子顶替和根节点变化都能统一处理。
+
+```cpp:line-numbers [bst-erase.cpp]
+#include <memory>
+
+struct BstNode {
+    explicit BstNode(int value) : key(value) {}
+    int key;
+    std::unique_ptr<BstNode> left;
+    std::unique_ptr<BstNode> right;
+};
+
+// 找到以 root 为根的子树中的最小关键字节点（最左节点）
+const BstNode& minimum(const BstNode& root) {
+    const BstNode* current = &root;
+    while (current->left) {
+        current = current->left.get();  // 一路向左，直到没有左孩子
+    }
+    return *current;
+}
+
+// 删除：返回删除后子树的新根，用 unique_ptr 自动管理内存
+std::unique_ptr<BstNode> erase(std::unique_ptr<BstNode> root, int key) {
+    if (!root) {
+        return nullptr;  // 走到空链接，目标不存在
+    }
+    if (key < root->key) {
+        // 目标在左子树，递归删除后更新左链接
+        root->left = erase(std::move(root->left), key);
+    } else if (key > root->key) {
+        // 目标在右子树，递归删除后更新右链接
+        root->right = erase(std::move(root->right), key);
+    } else {
+        // 找到目标节点，分三种结构情况处理
+        if (!root->left) {
+            // 情况 1/2：没有左孩子，用右孩子顶替（右孩子可为空）
+            return std::move(root->right);
+        }
+        if (!root->right) {
+            // 情况 2：没有右孩子，用左孩子顶替
+            return std::move(root->left);
+        }
+        // 情况 3：有两个孩子，用右子树最小值（后继）替换当前关键字
+        root->key = minimum(*root->right).key;
+        // 再递归删除右子树中那个已经被"复制"上来的后继节点
+        root->right = erase(std::move(root->right), root->key);
+    }
+    return root;
+}
+```
+
+
+
+## 5.1.2 二叉搜索树的复杂度与退化【C/C++】
 
 ### 所有核心操作都受树高控制
 
@@ -180,53 +240,58 @@ digraph DegenerateBst {
 上面的退化树仍完全满足 BST 有序性质，中序序列也正确。问题不是“树错了”，而是有序不变量没有对高度作任何保证。仅检查中序递增，无法证明性能达标。
 :::
 
-### C++：用唯一所有权实现删除
 
-下面的删除函数使用 `std::unique_ptr` 表达“父节点独占孩子”的所有权。返回值始终是删除后子树的新根，因此叶删除、单孩子顶替和根节点变化都能统一处理。
 
-```cpp:line-numbers [bst-erase.cpp]
-#include <memory>
+### 交互式演示 · BST 操作
 
-struct BstNode {
-    explicit BstNode(int value) : key(value) {}
-    int key;
-    std::unique_ptr<BstNode> left;
-    std::unique_ptr<BstNode> right;
-};
+下面的演示可以亲手体验 BST 的插入、查找与删除。尝试依次插入 `1, 2, 3, 4, 5` 观察退化链，再换一组平衡序列如 `8, 3, 10, 1, 6, 14` 对比树高；也可以选中节点后点击删除，观察三种结构情况的处理。
 
-const BstNode& minimum(const BstNode& root) {
-    const BstNode* current = &root;
-    while (current->left) {
-        current = current->left.get();
-    }
-    return *current;
-}
+<script setup>
+import { withBase } from "vitepress";
 
-std::unique_ptr<BstNode> erase(std::unique_ptr<BstNode> root, int key) {
-    if (!root) {
-        return nullptr;
-    }
-    if (key < root->key) {
-        root->left = erase(std::move(root->left), key);
-    } else if (key > root->key) {
-        root->right = erase(std::move(root->right), key);
-    } else {
-        if (!root->left) {
-            return std::move(root->right);
-        }
-        if (!root->right) {
-            return std::move(root->left);
-        }
-        root->key = minimum(*root->right).key;
-        root->right = erase(std::move(root->right), root->key);
-    }
-    return root;
-}
-```
+// 本页两个交互演示的地址统一在此定义
+// （Vue 单文件组件只允许一个 <script setup>，故不能为每个演示各写一个）
+const bstDemoUrl = withBase("/demos/bst-explorer.html");
+const avlDemoUrl = withBase("/demos/avl-lab.html");
+</script>
+
+<iframe
+  :src="bstDemoUrl"
+  title="二叉搜索树 · 插入与删除可视化"
+  class="tree-demo-frame"
+  loading="lazy"
+></iframe>
+
+::: tip 观察重点
+1. 用递增序列插入，看树如何退化成链；
+2. 用同一组关键字的不同插入顺序，对比树高与查找路径长度；
+3. 选中节点删除，观察叶节点、单孩子、双孩子三种情况的处理逻辑。
+::: 
 
 递归深度仍为 $O(h)$。若普通 BST 可能接收恶意有序输入，退化深度还会带来调用栈风险；这正是平衡树要解决的问题。
 
-## 5.1.3 平衡的思想与旋转操作
+
+
+## 5.1.3 对于旋转和非旋转的讨论
+
+笔者认为，常见平衡树分别通过旋转和非旋转两种方式去实现平衡。大学数据结构相关教材中只提及了几类旋转平衡树，故笔者在此处想拓展一些非旋转平衡树，以起到抛砖引玉之效。
+
+
+
+**旋转——用局部旋转修复失衡。** AVL、Splay、Treap 以及红黑树都属于这一类平衡树（AVL和红黑树多见于各种大学教材）。它们的共同点是通过某种约定判断某个子树"歪了"的时候，就通过左旋或右旋把重心拉回来。旋转的优势在于只改常数条链接，$O(1)$ 就能完成一次结构调整。OI-Wiki 上有对旋转的经典总结是：**"旋转操作是多数平衡树能够维持平衡的关键，它能在不改变一棵合法 BST 中序遍历结果的情况下改变局部节点的深度。"** [^oiwiki-rotate]
+
+（旋转平衡树如果不够熟悉，写的时候可能会有绕晕的风险。
+
+**非旋——绕开旋转，用别的方式保持平衡。** 这一类平衡树在算法竞赛中反而更受欢迎，原因很简单：**好写、好调、不容易写挂。**
+
+- **FHQ Treap（非旋 Treap）**：完全取消旋转，只用**分裂（Split）**和**合并（Merge）**两个操作。按关键字把树劈成两半，递归处理完再粘回去。FHQ Treap 在 OI 中普及的一个很重要原因是它天然支持区间操作，这是旋转很难优雅做到的。
+- **替罪羊树（Scapegoat Tree）**：很暴力，不过实际上很优雅，采用暴力重建的方法来代替旋转。一旦某个子树的节点数超过整棵树的 $\alpha$ 倍（通常取 0.7 或 0.8），就**拍扁重建**——把子树里的所有节点拿出来排好序，重新建一棵完全平衡的 BST。 替罪羊树的均摊复杂度仍是 $O(\log n)$，单次重建最坏 $O(n)$，但触发频率被控制得很低，实际运行起来相当快。
+
+此处笔者只是从算法竞赛角度略作拓展，大学课程中还是以 AVL 和 红黑树 为重。
+
+
+
+## 5.1.4 平衡的思想与旋转操作
 
 ### 平衡不是让两边节点数完全相等
 
@@ -290,7 +355,7 @@ digraph RightRotation {
 
 每次旋转后必须自底向上更新受影响节点的高度。右旋时先更新下降的 `y`，再更新上升的 `x`；顺序反过来会读取旧高度。
 
-## 5.1.4 AVL 树：平衡因子、四种失衡与单/双旋转、插入、删除【进阶】
+## 5.1.5 AVL 树：平衡因子、四种失衡与单/双旋转、插入、删除【进阶】
 
 ### 平衡因子与 AVL 不变量
 
@@ -427,7 +492,7 @@ AVL 删除先执行 BST 删除。与插入不同，删除可能让子树高度�
 LL 失衡使用一次**右旋**，RR 失衡使用一次**左旋**。名称表示重路径从失衡根出发走向哪两个方向，不是要执行的旋转方向。
 :::
 
-## 5.1.5 AVL 树的实现与复杂度【C/C++】
+## 5.1.6 AVL 树的实现与复杂度【C/C++】
 
 下面的 C++ 核心实现把高度维护、单旋和双旋统一放在 `rebalance` 中。`insert` 与 `erase` 只负责 BST 语义，返回前都经过同一再平衡出口。
 
@@ -435,35 +500,43 @@ LL 失衡使用一次**右旋**，RR 失衡使用一次**左旋**。名称表示
 #include <algorithm>
 #include <memory>
 
+// AVL 节点：比普通 BST 多一个 height 字段，用于判断失衡
 struct AvlNode {
     explicit AvlNode(int value) : key(value) {}
     int key;
-    int height{0};
+    int height{0};                       // 叶节点高度为 0
     std::unique_ptr<AvlNode> left;
     std::unique_ptr<AvlNode> right;
 };
 
+// 辅助函数：空树高度为 -1，否则取节点记录的高度
 int height(const std::unique_ptr<AvlNode>& node) {
     return node ? node->height : -1;
 }
 
+// 根据左右孩子高度重新计算当前节点高度
 void update(AvlNode& node) {
     node.height = 1 + std::max(height(node.left), height(node.right));
 }
 
+// 平衡因子 = 左子树高度 - 右子树高度
+// AVL 要求平衡因子在 {-1, 0, 1} 范围内
 int balanceFactor(const AvlNode& node) {
     return height(node.left) - height(node.right);
 }
 
+// 右旋：pivot 是当前根的左孩子，右旋后 pivot 上升为新根
+// 中间子树 B 从 pivot 的右侧改挂到原根的左侧
 std::unique_ptr<AvlNode> rotateRight(std::unique_ptr<AvlNode> root) {
-    auto pivot = std::move(root->left);
-    root->left = std::move(pivot->right);
-    update(*root);                  // 先更新下降节点
-    pivot->right = std::move(root);
-    update(*pivot);
-    return pivot;
+    auto pivot = std::move(root->left);     // ① 保存左孩子 pivot
+    root->left = std::move(pivot->right);   // ② pivot 的右子树变成 root 的左子树
+    update(*root);                          // ③ 先更新下降节点 root 的高度
+    pivot->right = std::move(root);         // ④ root 成为 pivot 的右孩子
+    update(*pivot);                         // ⑤ 再更新上升节点 pivot 的高度
+    return pivot;                           // ⑥ 返回新根
 }
 
+// 左旋：与右旋完全对称
 std::unique_ptr<AvlNode> rotateLeft(std::unique_ptr<AvlNode> root) {
     auto pivot = std::move(root->right);
     root->right = std::move(pivot->left);
@@ -473,58 +546,81 @@ std::unique_ptr<AvlNode> rotateLeft(std::unique_ptr<AvlNode> root) {
     return pivot;
 }
 
+// 再平衡：根据平衡因子判断失衡类型，选择单旋或双旋
 std::unique_ptr<AvlNode> rebalance(std::unique_ptr<AvlNode> root) {
-    update(*root);
-    if (balanceFactor(*root) > 1) {
-        if (balanceFactor(*root->left) < 0) {           // LR
-            root->left = rotateLeft(std::move(root->left));
+    update(*root);                          // 先更新当前节点高度
+    if (balanceFactor(*root) > 1) {         // 左子树过高
+        if (balanceFactor(*root->left) < 0) {           // 左孩子右偏 → LR
+            root->left = rotateLeft(std::move(root->left)); // 先左旋左孩子
         }
-        return rotateRight(std::move(root));             // LL
+        return rotateRight(std::move(root));             // LL（或 LR 调整后）右旋
     }
-    if (balanceFactor(*root) < -1) {
-        if (balanceFactor(*root->right) > 0) {           // RL
-            root->right = rotateRight(std::move(root->right));
+    if (balanceFactor(*root) < -1) {        // 右子树过高
+        if (balanceFactor(*root->right) > 0) {           // 右孩子左偏 → RL
+            root->right = rotateRight(std::move(root->right)); // 先右旋右孩子
         }
-        return rotateLeft(std::move(root));              // RR
+        return rotateLeft(std::move(root));              // RR（或 RL 调整后）左旋
     }
-    return root;
+    return root;                            // 平衡，无需旋转
 }
 
+// AVL 插入：先按 BST 规则插入，返回时沿途再平衡
 std::unique_ptr<AvlNode> insert(std::unique_ptr<AvlNode> root, int key) {
     if (!root) {
-        return std::make_unique<AvlNode>(key);
+        return std::make_unique<AvlNode>(key);  // 空位置，创建新节点
     }
     if (key < root->key) {
-        root->left = insert(std::move(root->left), key);
+        root->left = insert(std::move(root->left), key);   // 递归插入左子树
     } else if (key > root->key) {
-        root->right = insert(std::move(root->right), key);
+        root->right = insert(std::move(root->right), key); // 递归插入右子树
     } else {
         return root;                                    // 拒绝重复键
     }
-    return rebalance(std::move(root));
+    return rebalance(std::move(root));                  // 回溯时再平衡
 }
 
+// 找子树最小值（最左节点）
 const AvlNode& minimum(const AvlNode& root) {
     const AvlNode* current = &root;
     while (current->left) current = current->left.get();
     return *current;
 }
 
+// AVL 删除：先按 BST 规则删除，返回时沿途再平衡
 std::unique_ptr<AvlNode> erase(std::unique_ptr<AvlNode> root, int key) {
-    if (!root) return nullptr;
+    if (!root) return nullptr;              // 空树，目标不存在
     if (key < root->key) {
-        root->left = erase(std::move(root->left), key);
+        root->left = erase(std::move(root->left), key);    // 递归删除左子树
     } else if (key > root->key) {
-        root->right = erase(std::move(root->right), key);
+        root->right = erase(std::move(root->right), key);  // 递归删除右子树
     } else {
-        if (!root->left) return std::move(root->right);
-        if (!root->right) return std::move(root->left);
+        // 找到目标，分三种结构情况
+        if (!root->left) return std::move(root->right);    // 用右孩子顶替
+        if (!root->right) return std::move(root->left);    // 用左孩子顶替
+        // 双孩子：用后继替换关键字，再递归删除后继
         root->key = minimum(*root->right).key;
         root->right = erase(std::move(root->right), root->key);
     }
-    return rebalance(std::move(root));
+    return rebalance(std::move(root));      // 回溯时再平衡（删除可能一路传到根）
 }
 ```
+
+### 交互式演示 · AVL 树平衡过程
+
+下面的演示可以观察 AVL 树的插入与再平衡过程。依次插入 `30, 10, 20` 体验 LR 双旋，或插入递增序列观察旋转如何阻止退化。
+
+<iframe
+  :src="avlDemoUrl"
+  title="AVL 树 · 插入与旋转可视化"
+  class="tree-demo-frame"
+  loading="lazy"
+></iframe>
+
+::: tip 观察重点
+1. 依次插入 `30, 10, 20`，观察 LR 双旋的完整过程；
+2. 插入递增序列，观察 AVL 如何通过单旋阻止退化成链；
+3. 注意每次插入后节点高度的更新和平衡因子的变化。
+::: 
 
 ::: complexity 复杂度 · AVL 操作
 AVL 树的最少节点数满足类似斐波那契的递推，因此高度为 $O(\log n)$。查找、插入、删除都只访问一条根到叶路径：
@@ -546,6 +642,204 @@ AVL 树的最少节点数满足类似斐波那契的递推，因此高度为 $O(
 4. 节点数与成功插入、删除记录一致；
 5. 空树、单节点、根删除、连续递增插入和交替插删均不泄漏或重复拥有节点。
 
+
+
+
+## 5.1.7 红黑树
+
+AVL 严格限制左右高度差。红黑树使用较宽松的颜色规则限制最长路径，使更新时通常需要更少旋转。
+
+把所有空孩子视为黑色 NIL 叶结点。一棵红黑树满足：
+
+1. 每个结点非红即黑；
+2. 根结点是黑色；
+3. 所有 NIL 叶结点是黑色；
+4. 红结点的两个孩子都是黑色，不能出现连续红结点；
+5. 从任一结点到其所有后代 NIL 叶结点的路径，都包含相同数量的黑结点。
+
+从某结点到后代 NIL 路径上的黑结点数称为**黑高**。性质 4 保证最长路径至多在每两个黑结点之间插入一个红结点，因此最长路径不会超过最短路径的两倍。
+
+::: definition 定义 · 黑高与红黑树
+一个结点的**黑高**是从该结点到其所有后代 NIL 叶的路径上经过的黑结点数（不含该结点本身）。红黑树通过"所有路径黑高相同"（性质 5）限制树高，又通过"无连续红结点"（性质 4）限制最长与最短路径之比。
+:::
+
+含 $n$ 个内部结点的红黑树高度满足：
+$$
+h\le 2\log_2(n+1).
+$$
+所以查找、插入、删除的最坏时间都是 $O(\log n)$。
+
+::: theorem 定理 · 红黑树高度上界
+性质 4 使最长路径上最多每两个黑结点夹一个红结点，故最长路径 ≤ $2\times$ 最短路径。又由性质 5 所有路径黑高相同为 $bh$，最短路径至少 $bh$ 个黑结点。一棵黑高为 $bh$ 的红黑树至少含 $2^{bh}-1$ 个内部结点，从而 $bh\le\log_2(n+1)$，所以 $h\le2bh\le2\log_2(n+1)$。
+:::
+
+## 红黑树插入的修复思路
+
+新结点按 BST 规则插入并染红。染红不会改变任一路径的黑高；唯一可能破坏的是"红结点不能有红孩子"。若父结点也是红色，观察叔叔结点：
+
+- **叔叔为红色**：把父和叔染黑、祖父染红，再从祖父继续向上检查；
+- **叔叔为黑色，路径成折线**：先旋转父结点，把折线变成直线；
+- **叔叔为黑色，路径成直线**：旋转祖父，并交换父与祖父的颜色。
+
+最后把根染黑。修复可能多次变色，但插入最多做常数次结构旋转。
+
+::: intuition 直觉 · 为什么新结点染红
+插入新结点若染黑，会让经过它那条路径的黑高比别的路径多 1，立刻破坏性质 5，而且这个破坏很难局部修复。染红则只可能破坏性质 4（父也是红），而"连续红"是可以通过变色和旋转在局部消除的。因此染红把问题变成一个更可控的局部约束。
+:::
+
+## 红黑树删除的修复思路
+
+删除红结点不会改变黑高；删除有红孩子的黑结点时，可让红孩子顶替并染黑。困难发生在删除黑色叶位置：某些路径会少一个黑结点，可把这个缺额理解为"额外一重黑色"。
+
+修复时根据兄弟颜色、兄弟孩子颜色决定变色和旋转，把黑色缺额向上移动或在局部消除。完整代码分支较多，但每一步都服务于两件事：恢复相同黑高，避免连续红结点。
+
+::: warning 不要用 AVL 的高度差判断红黑树
+红黑树不要求任意结点左右子树高度差不超过 1。它只通过颜色和黑高限制整体最长路径，因此可能比同关键字集合的 AVL 更高。
+:::
+
+### 完整实现：红黑树（C++）
+
+下面给出一份维护颜色、带哨兵 NIL 的红黑树核心实现。插入和删除的修复逻辑严格按照前文所述的变色与旋转策略实现。
+
+```cpp:line-numbers [red-black-tree.cpp]
+#include <memory>
+
+enum class Color { RED, BLACK };
+
+struct RbNode {
+    int key;
+    Color color{Color::RED};            // 新节点默认染红
+    std::shared_ptr<RbNode> left;
+    std::shared_ptr<RbNode> right;
+    std::weak_ptr<RbNode> parent;       // 需要父指针做向上修复
+};
+
+using NodePtr = std::shared_ptr<RbNode>;
+
+// ---------- 辅助旋转 ----------
+void leftRotate(NodePtr& root, NodePtr x) {
+    NodePtr y = x->right;               // y 是 x 的右孩子
+    x->right = y->left;                 // y 的左子树变成 x 的右子树
+    if (y->left) {
+        y->left->parent = x;
+    }
+    y->parent = x->parent;              // y 接替 x 的位置
+    if (!x->parent.lock()) {
+        root = y;                       // x 原来是根
+    } else if (x == x->parent.lock()->left) {
+        x->parent.lock()->left = y;
+    } else {
+        x->parent.lock()->right = y;
+    }
+    y->left = x;
+    x->parent = y;
+}
+
+void rightRotate(NodePtr& root, NodePtr x) {
+    NodePtr y = x->left;
+    x->left = y->right;
+    if (y->right) {
+        y->right->parent = x;
+    }
+    y->parent = x->parent;
+    if (!x->parent.lock()) {
+        root = y;
+    } else if (x == x->parent.lock()->right) {
+        x->parent.lock()->right = y;
+    } else {
+        x->parent.lock()->left = y;
+    }
+    y->right = x;
+    x->parent = y;
+}
+
+// ---------- 插入修复 ----------
+void insertFixup(NodePtr& root, NodePtr z) {
+    // 只要父节点是红色，就违反了"无连续红节点"的性质
+    while (z->parent.lock() && z->parent.lock()->color == Color::RED) {
+        NodePtr p = z->parent.lock();
+        NodePtr g = p->parent.lock();   // 祖父节点
+        if (p == g->left) {             // 父节点是左孩子
+            NodePtr u = g->right;       // 叔叔节点
+            if (u && u->color == Color::RED) {
+                // 情况 1：叔叔为红，变色后向上继续检查
+                p->color = Color::BLACK;
+                u->color = Color::BLACK;
+                g->color = Color::RED;
+                z = g;
+            } else {
+                // 叔叔为黑
+                if (z == p->right) {
+                    // 情况 2：折线，先左旋父节点拉成直线
+                    z = p;
+                    leftRotate(root, z);
+                    p = z->parent.lock();
+                    g = p->parent.lock();
+                }
+                // 情况 3：直线，右旋祖父并变色
+                p->color = Color::BLACK;
+                g->color = Color::RED;
+                rightRotate(root, g);
+            }
+        } else {
+            // 对称情况：父节点是右孩子
+            NodePtr u = g->left;
+            if (u && u->color == Color::RED) {
+                p->color = Color::BLACK;
+                u->color = Color::BLACK;
+                g->color = Color::RED;
+                z = g;
+            } else {
+                if (z == p->left) {
+                    z = p;
+                    rightRotate(root, z);
+                    p = z->parent.lock();
+                    g = p->parent.lock();
+                }
+                p->color = Color::BLACK;
+                g->color = Color::RED;
+                leftRotate(root, g);
+            }
+        }
+    }
+    root->color = Color::BLACK;         // 根始终为黑
+}
+
+// ---------- 公开插入接口 ----------
+NodePtr rbInsert(NodePtr root, int key) {
+    NodePtr z = std::make_shared<RbNode>();
+    z->key = key;
+
+    NodePtr y;                          // 追踪父节点位置
+    NodePtr x = root;
+    while (x) {
+        y = x;
+        if (key < x->key) {
+            x = x->left;
+        } else {
+            x = x->right;
+        }
+    }
+    z->parent = y;
+    if (!y) {
+        root = z;                       // 空树，z 成为根
+    } else if (key < y->key) {
+        y->left = z;
+    } else {
+        y->right = z;
+    }
+
+    insertFixup(root, z);
+    return root;
+}
+```
+
+::: tip 红黑树实现要点
+- 新节点默认染**红**，这样只可能破坏"无连续红节点"的性质，而不会破坏所有路径黑高相同的性质；
+- 修复时始终关注**叔叔节点**的颜色：叔叔为红则变色上移，叔叔为黑则通过旋转+变色在局部解决；
+- 左旋和右旋的实现与 AVL 基本相同，只是额外维护了 `parent` 指针；
+- 删除修复比插入更复杂，核心思想是把"黑节点 deficit"（双重黑）向上传递或在局部消除。
+::: 
 ## 配套 Lab
 
 | 实验 | 练习内容 |
@@ -580,3 +874,21 @@ BST 用全序关系缩小查找范围，但性能仍由树高决定；AVL 在每
 :::
 
 下一节进入[5.2 堆与优先队列](./02-heap-and-priority-queue.md)：它不维护完整排序，而是用更弱的局部偏序换取高效的最高优先级访问。
+
+<style scoped>
+.tree-demo-frame {
+  display: block;
+  width: 100%;
+  height: 760px;
+  margin: 20px 0;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: var(--course-code-bg);
+}
+
+@media (max-width: 720px) {
+  .tree-demo-frame {
+    height: 1100px;
+  }
+}
+</style>

--- a/content/chapter-05-tree-applications/02-heap-and-priority-queue.md
+++ b/content/chapter-05-tree-applications/02-heap-and-priority-queue.md
@@ -4,8 +4,8 @@ description: "从完全二叉树的数组表示出发，实现堆调整、线性
 order: 2
 chapter: 5
 chapterTitle: "树的应用"
-updated: "2026-08-24"
-contributors: ["Azen"]
+updated: "2026-09-10"
+contributors: ["CzjLUCK&Azen"]
 status: "review"
 ---
 
@@ -24,7 +24,7 @@ status: "review"
 
 ## 5.2.1 堆的定义与数组表示（含父/子下标关系）
 
-### 完全二叉树 + 局部偏序
+### 局部偏序性
 
 ::: definition 定义 · 二叉堆
 <dfn>二叉堆</dfn>是一棵满足完全二叉树形态，并满足堆序性质的二叉树：
@@ -37,11 +37,15 @@ status: "review"
 
 大根堆的根一定是全局最大值：任意节点沿父链接回到根，关键字不会增加。小根堆同理保证根为全局最小值。
 
+笔者要强调的是，堆只能维护最值，不能维护次值等信息。
+
 ::: counterexample 反例 · 堆不是有序数组
 数组 `[90, 70, 80, 10, 60, 30, 50]` 是合法大根堆，但 `70 < 80`，数组前缀并非递减序列。不能在堆数组上使用二分查找，也不能认为第二个元素就是第二大值。
 :::
 
-### 0-based 数组表示
+### 数组表示
+
+二叉堆的节点编号很容易表示，因为这是一颗完全二叉树。
 
 完全二叉树逐层从左到右没有空洞，因此无需保存指针。对数组下标 `i`：
 
@@ -102,22 +106,26 @@ digraph HeapArray {
 在数组末尾插入新值后，只有“新节点—父节点”关系可能违规。若新值大于父值，就交换并继续向上，直到到达根或父值已经不小于它。
 
 ```cpp:line-numbers [max-heap-sift-up.cpp]
-#include <cstddef>
-#include <utility>
-#include <vector>
-
+// 上浮：把下标 index 处的元素逐层与父节点比较交换，恢复“父 >= 子”的大根堆性质
+// 调用前提：除 index 到根的路径外，堆其余部分已满足堆序（例如刚在末尾 push 了新值）
 void siftUp(std::vector<int>& heap, std::size_t index) {
+    // ① 只要还没到达根（index == 0 即根），就继续向上检查
     while (index > 0) {
+        // 完全二叉树中，下标 i 的父节点下标为 (i-1)/2
+        // 必须先判 index > 0 再算 index-1：无符号下标在 0 处减 1 会下溢成巨大值
         const std::size_t parent = (index - 1) / 2;
+        // ② 父值已经不小于当前值 -> 堆序恢复，立即停止
         if (heap[parent] >= heap[index]) break;
+        // ③ 父子交换，当前元素上浮一层；下一轮检查新的父节点
         std::swap(heap[parent], heap[index]);
         index = parent;
     }
 }
 
+// 插入：先放到数组末尾（保持完全二叉树的形状），再上浮修复堆序
 void push(std::vector<int>& heap, int value) {
-    heap.push_back(value);
-    siftUp(heap, heap.size() - 1);
+    heap.push_back(value);              // 新元素暂居末尾，此时只有它到根的路径可能违规
+    siftUp(heap, heap.size() - 1);      // 从末尾（新元素下标）开始上浮
 }
 ```
 
@@ -126,31 +134,36 @@ void push(std::vector<int>& heap, int value) {
 删除堆顶时，先保存根值，再把数组最后一个元素移到根并缩短数组。此时只有根到某个叶节点的路径可能违规。大根堆每一步必须与两个孩子中更大的那个比较；若误选较小孩子，交换后仍可能小于另一个孩子。
 
 ```cpp:line-numbers [max-heap-sift-down.cpp]
-#include <cstddef>
-#include <stdexcept>
-#include <utility>
-#include <vector>
-
+// 下沉：把下标 index 处的元素与两个孩子中较大者比较交换，恢复堆序
+// 调用前提：除 index 到某片叶子的路径外，其余部分已满足堆序
 void siftDown(std::vector<int>& heap, std::size_t index) {
     const std::size_t n = heap.size();
     while (true) {
-        std::size_t best = index;
+        std::size_t best = index;       // best 记录“当前节点与两个孩子”中最大值的下标
+        // 完全二叉树中，下标 i 的左右孩子下标为 2i+1、2i+2
         const std::size_t left = 2 * index + 1;
         const std::size_t right = left + 1;
+        // ① 先与左孩子比（left < n 保证孩子存在，访问无符号下标前必须先判界）
         if (left < n && heap[left] > heap[best]) best = left;
+        // ② 再与右孩子比，且比较对象是 heap[best] 而不是 heap[index]：
+        //    大根堆每一步必须选两个孩子里的较大者，若误选较小者，
+        //    交换后仍可能小于另一个孩子，堆序无法恢复
         if (right < n && heap[right] > heap[best]) best = right;
+        // ③ 两个孩子都不比当前节点大 -> 堆序已恢复，结束
         if (best == index) break;
-        std::swap(heap[index], heap[best]);
-        index = best;
+        std::swap(heap[index], heap[best]);  // 与较强孩子交换，当前元素下沉一层
+        index = best;                        // 继续检查新位置
     }
 }
 
+// 删除堆顶：用末尾元素顶替根，再从根下沉
 int pop(std::vector<int>& heap) {
     if (heap.empty()) throw std::out_of_range("empty heap");
-    const int top = heap.front();
-    heap.front() = heap.back();
-    heap.pop_back();
-    if (!heap.empty()) siftDown(heap, 0);
+    const int top = heap.front();       // ① 先保存堆顶作为返回值
+    heap.front() = heap.back();         // ② 末尾元素移到根，保持完全二叉树形状
+    heap.pop_back();                    //    数组缩短一格
+    if (!heap.empty()) siftDown(heap, 0);  // ③ 新根可能小于孩子，从根下沉；
+                                           //    仅剩一个元素时无需下沉
     return top;
 }
 ```
@@ -179,8 +192,16 @@ int pop(std::vector<int>& heap) {
 
 ```cpp:line-numbers [heapify.cpp]
 // 沿用上一节的 siftDown 与其头文件
+// 自底向上建堆（Heapify）：从最后一个非叶节点开始向根逐个下沉
+// 正确性依据：对下标 i 做下沉时，它的左右子树已经是合法堆，
+//             因此一次下沉即可让 i 的子树也成为合法堆，
+//             自底向上处理保证了“子树先于父节点”这一顺序
 void heapify(std::vector<int>& values) {
-    if (values.size() < 2) return;
+    if (values.size() < 2) return;      // 0 或 1 个元素的数组天然是堆
+    // 完全二叉树中，下标 >= n/2 的节点都是叶子（没有孩子），无需处理，
+    // 故只需对 0 .. n/2-1 这些非叶节点各做一次下沉
+    // 循环条件 i-- > 0：先取用 i 再自减，使 i 依次取 n/2-1, ..., 1, 0
+    // 若写成 i >= 0，i 在 0 之后下溢成 SIZE_MAX，会造成死循环
     for (std::size_t i = values.size() / 2; i-- > 0;) {
         siftDown(values, i);
     }
@@ -214,11 +235,16 @@ $$
 
 ```cpp:line-numbers [heap-sort.cpp]
 // 沿用上面的 heapify；siftDownRange 是 siftDown 的“限定右边界”版本
+// 堆排序过程中数组被切成 [堆区 | 已排序区]：
+//   已排序区是 values[end .. n-1]，堆区是 values[0 .. end-1)
+// 因此下沉时只允许比较下标 < end 的孩子，end 充当堆区右边界
 void siftDownRange(std::vector<int>& values, std::size_t index, std::size_t end) {
     while (true) {
         std::size_t best = index;
         const std::size_t left = 2 * index + 1;
         const std::size_t right = left + 1;
+        // 与 siftDown 相同，只是越界判断改为 end：
+        // end 之后的元素已经到达最终位置，绝不能把它们交换回堆区
         if (left < end && values[left] > values[best]) best = left;
         if (right < end && values[right] > values[best]) best = right;
         if (best == index) return;
@@ -227,11 +253,14 @@ void siftDownRange(std::vector<int>& values, std::size_t index, std::size_t end)
     }
 }
 
+// 升序堆排序：大根堆 + 反复把堆顶交换到当前末尾
 void heapSort(std::vector<int>& values) {
-    heapify(values);
+    heapify(values);                    // ① 先把整个数组建成大根堆
+    // ② 每轮把堆顶（当前最大者）与堆区末尾交换，堆区缩小一格
+    //    end 从 n 递减到 2；end == 1 时只剩一个元素，天然有序
     for (std::size_t end = values.size(); end > 1; --end) {
         std::swap(values[0], values[end - 1]);
-        siftDownRange(values, 0, end - 1);  // 只调整 [0, end-1)
+        siftDownRange(values, 0, end - 1);  // ③ 新堆顶可能小于孩子，只在 [0, end-1) 内下沉
     }
 }
 ```
@@ -267,13 +296,16 @@ C++ 的 `std::priority_queue` 默认是大根优先队列：
 #include <queue>
 #include <vector>
 
+// std::priority_queue 默认是大根堆：堆顶为当前最大元素
 std::priority_queue<int> maxQueue;
 maxQueue.push(7);
 maxQueue.push(2);
 maxQueue.push(9);
-int largest = maxQueue.top();  // 9
-maxQueue.pop();
+int largest = maxQueue.top();  // 9：top() 只读取不删除；pop() 无返回值，两者要分开调用
+maxQueue.pop();                // 删除堆顶 9
 
+// 想要小根堆，必须显式给出全部三个模板参数：
+//   元素类型、底层容器（保持默认 std::vector）、比较器（std::greater 让“小”的排前面）
 std::priority_queue<int, std::vector<int>, std::greater<int>> minQueue;
 minQueue.push(7);
 minQueue.push(2);
@@ -304,14 +336,18 @@ int smallest = minQueue.top(); // 2
 #include <stdexcept>
 #include <vector>
 
+// 求第 k 大：维护一个大小恰为 k 的小根堆 kept
+// 核心不变量：kept 中保存“目前见过的最大的 k 个元素”，堆顶是这 k 个里的最小者
 int kthLargest(const std::vector<int>& values, std::size_t k) {
     if (k == 0 || k > values.size()) throw std::out_of_range("invalid k");
+    // greater 比较器 -> 小根堆，堆顶是当前 Top-K 中最小的那个
     std::priority_queue<int, std::vector<int>, std::greater<int>> kept;
     for (int value : values) {
-        kept.push(value);
-        if (kept.size() > k) kept.pop();
+        kept.push(value);                   // ① 新元素入堆
+        if (kept.size() > k) kept.pop();    // ② 超过 k 个就弹掉最小者：
+                                            //    新元素够大时顶替它，不够大时弹掉的正是新元素
     }
-    return kept.top();
+    return kept.top();  // ③ 堆里剩最大的 k 个，其中最小者即全体的第 k 大
 }
 ```
 
@@ -339,6 +375,26 @@ $$
 ::: example 示例 · 延迟任务队列
 若任务以 `(nextRunTime, sequence)` 排序，小根堆顶就是最早应执行的任务；`sequence` 保证时间相同的任务按到达顺序稳定处理。任务执行后若要周期性重排，更新下一次时间并重新入堆，而不是直接修改堆内键值。
 :::
+
+## 5.2.6 对可合并性的讨论
+
+二叉堆由于节点下标较为固定，难以实现合并。
+
+笔者在此处简单拓展两个算法竞赛中常见的可并堆，以激发读者兴趣。
+
+### 配对堆
+
+配对堆是一个支持插入，查询/删除最小值，合并，修改元素等操作的数据结构，是一种可并堆．有速度快和结构简单的优势，但由于其为基于势能分析的均摊复杂度，无法可持久化．
+
+### 左偏树
+
+对于一棵二叉树，我们定义 **外节点** 为子节点数小于两个的节点，定义一个节点的dis为其到子树中最近的外节点所经过的边的数量．空节点的dis为 0![0](data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7)．
+
+左偏树是一棵二叉树，它不仅具有堆的性质，并且是「左偏」的：每个节点左儿子的 dist![\mathrm{dist}](data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7) 都大于等于右儿子的 dis。因此，左偏树每个节点的dis都等于其右儿子的 dis 加一．
+
+需要注意的是，dis 不是深度，**左偏树的深度没有保证**，一条向左的链也符合左偏树的定义．
+
+
 
 ## 配套 Lab
 

--- a/content/chapter-05-tree-applications/03-huffman-tree-and-coding.md
+++ b/content/chapter-05-tree-applications/03-huffman-tree-and-coding.md
@@ -4,8 +4,8 @@ description: "从带权路径长度出发，用贪心与优先队列构造最优
 order: 3
 chapter: 5
 chapterTitle: "树的应用"
-updated: "2026-08-24"
-contributors: ["Azen"]
+updated: "2026-09-10"
+contributors: ["CzjLUCK&Azen"]
 status: "review"
 ---
 
@@ -211,9 +211,10 @@ digraph HuffmanTree {
 #include <utility>
 #include <vector>
 
+// 赫夫曼树节点：内部节点 weight 为左右子权重之和，symbol 用 '\0' 占位
 struct HuffmanNode {
-    long long weight;
-    char symbol{};
+    long long weight;                            // 子树权重（叶子 = 符号频数）
+    char symbol{};                               // 叶子符号；内部节点保持 '\0'
     std::shared_ptr<HuffmanNode> left;
     std::shared_ptr<HuffmanNode> right;
 
@@ -223,47 +224,57 @@ struct HuffmanNode {
         : weight(nodeWeight), symbol(nodeSymbol),
           left(std::move(leftChild)), right(std::move(rightChild)) {}
 
-    bool isLeaf() const { return !left && !right; }
+    bool isLeaf() const { return !left && !right; }  // 赫夫曼树是满二叉树：无孩子即叶
 };
 
 using NodePtr = std::shared_ptr<HuffmanNode>;
 
+// priority_queue 默认是大根堆（“最大的”在顶），
+// 这里反向写比较器，让权重最小的节点位于堆顶
 struct Lighter {
     bool operator()(const NodePtr& a, const NodePtr& b) const {
-        return a->weight > b->weight;  // 小权重位于队首
+        return a->weight > b->weight;  // a 权重大 -> a 更不该在顶 -> 小权重位于队首
     }
 };
 
+// 构造赫夫曼树：每轮合并两个最小权重节点，直至只剩一棵树
 NodePtr buildHuffman(const std::vector<std::pair<char, int>>& frequencies) {
     std::priority_queue<NodePtr, std::vector<NodePtr>, Lighter> queue;
     std::unordered_set<char> symbols;
     for (const auto& [symbol, weight] : frequencies) {
         if (weight <= 0) throw std::invalid_argument("weight must be positive");
-        if (!symbols.insert(symbol).second) {
+        if (!symbols.insert(symbol).second) {      // 符号查重：重复符号无法构造唯一编码
             throw std::invalid_argument("duplicate symbol");
         }
+        // ① 每个符号先建成单节点树入堆
         queue.push(std::make_shared<HuffmanNode>(weight, symbol));
     }
-    if (queue.empty()) return nullptr;
+    if (queue.empty()) return nullptr;   // 空输入没有树可建
 
+    // ② 循环不变量：堆中每棵树的 weight 等于它覆盖符号的频数总和
+    //    每轮弹出两个最小者合并，新节点权重为两者之和——相当于把两个“区间”拼起来
     while (queue.size() > 1) {
         NodePtr left = queue.top(); queue.pop();
         NodePtr right = queue.top(); queue.pop();
         queue.push(std::make_shared<HuffmanNode>(
             left->weight + right->weight, '\0', left, right));
     }
+    // ③ 只剩一棵树，即为带权路径长度（WPL）最小的赫夫曼树
     return queue.top();
 }
 
+// 递归生成码表：从根走到叶，沿路记下 '0'/'1' 即为该符号的码字
 void buildCodes(const NodePtr& node, std::string path,
                 std::unordered_map<char, std::string>& codes) {
-    if (!node) return;
+    if (!node) return;                   // 防御空树
     if (node->isLeaf()) {
+        // 单符号特例：没有任何树边可走，path 为空串；
+        // 约定编码为 "0" 而非空串，否则无法从比特流判断该符号重复了几次
         codes[node->symbol] = path.empty() ? "0" : path;
         return;
     }
-    buildCodes(node->left, path + '0', codes);
-    buildCodes(node->right, path + '1', codes);
+    buildCodes(node->left, path + '0', codes);   // 向左走记 0
+    buildCodes(node->right, path + '1', codes);  // 向右走记 1
 }
 ```
 

--- a/content/chapter-05-tree-applications/04-disjoint-set-union.md
+++ b/content/chapter-05-tree-applications/04-disjoint-set-union.md
@@ -4,8 +4,8 @@ description: "用双亲数组维护集合划分，掌握路径压缩、按秩合
 order: 4
 chapter: 5
 chapterTitle: "树的应用"
-updated: "2026-08-24"
-contributors: ["Azen"]
+updated: "2026-09-10"
+contributors: ["CzjLUCK&Azen"]
 status: "review"
 ---
 
@@ -111,9 +111,11 @@ $$
 ```cpp:line-numbers [dsu-basic-find.cpp]
 #include <vector>
 
+// Find：沿父链接一路向上，直到某个节点的父节点是它自己——那即是根
+// 根就是该连通分量的代表元；本版本只读不改，不改变树的形状
 int findRoot(const std::vector<int>& parent, int x) {
-    while (parent[x] != x) {
-        x = parent[x];
+    while (parent[x] != x) {   // parent[x] == x 即到达根
+        x = parent[x];         // 上跳一层
     }
     return x;
 }
@@ -127,12 +129,13 @@ int findRoot(const std::vector<int>& parent, int x) {
 
 ```cpp:line-numbers [dsu-basic-union.cpp]
 // 沿用上面的 findRoot
+// Union：把 b 所在集合并入 a 所在集合
 bool unite(std::vector<int>& parent, int a, int b) {
-    int rootA = findRoot(parent, a);
-    int rootB = findRoot(parent, b);
-    if (rootA == rootB) return false;
-    parent[rootB] = rootA;
-    return true;
+    int rootA = findRoot(parent, a);   // ① 必须先找到两端的“根”
+    int rootB = findRoot(parent, b);   //    直接挂任意节点会撕掉子树或制造环
+    if (rootA == rootB) return false;  // ② 同根 -> 本来就同组，划分没有变化
+    parent[rootB] = rootA;             // ③ 把一个根挂到另一个根下面
+    return true;                       //    返回 true 表示发生了一次有效合并
 }
 ```
 
@@ -187,8 +190,12 @@ digraph PathCompression {
 
 ```cpp:line-numbers [path-compression.cpp]
 // DisjointSetUnion 的成员函数片段，parent_ 为成员数组
+// Find + 路径压缩（递归版）：
+//   返回值不变（仍是根），副作用是把 x 到根路径上的每个节点直接挂到根下
 int find(int x) {
     if (parent_[x] != x) {
+        // 递归先找到根，再“回填”：赋值号左边的 parent_[x] 被改写为根
+        // 一行同时完成“查根”和“压缩”，是最短写法
         parent_[x] = find(parent_[x]);
     }
     return parent_[x];
@@ -203,13 +210,14 @@ int find(int x) {
 
 ```cpp:line-numbers [union-by-size.cpp]
 // 同为成员函数片段，需要 <utility> 提供 std::swap
+// Union + 按大小合并：让小集合的根挂到大集合的根下
 bool unite(int a, int b) {
-    a = find(a);
+    a = find(a);                       // ① 合并永远发生在“根”与“根”之间
     b = find(b);
-    if (a == b) return false;
-    if (size_[a] < size_[b]) std::swap(a, b);
-    parent_[b] = a;
-    size_[a] += size_[b];
+    if (a == b) return false;          // ② 同根则无事发生
+    if (size_[a] < size_[b]) std::swap(a, b);  // ③ 保证 a 是大树根、b 是小树根
+    parent_[b] = a;                    //    小根挂大根：节点深度至多 O(log n) 增长
+    size_[a] += size_[b];              // ④ 只有根节点的 size 有意义，新根累计两个集合大小
     return true;
 }
 ```
@@ -230,18 +238,23 @@ bool unite(int a, int b) {
 #include <utility>
 #include <vector>
 
+// 完整并查集：路径压缩 + 按大小合并，单次操作均摊近似 O(alpha(n))
 class DisjointSetUnion {
 public:
     explicit DisjointSetUnion(int n)
         : parent_(checkedSize(n)), size_(checkedSize(n), 1), sets_(n) {
+        // 初始时每个元素自成一个集合：i 的父节点是 i 自己，集合大小为 1
         std::iota(parent_.begin(), parent_.end(), 0);
     }
 
+    // Find（迭代 + 两遍路径压缩）：
+    //   第一遍循环只负责找到根；第二遍把 x 沿途的每个节点直接指向根。
+    //   用迭代而非递归，避免极端长链下递归栈溢出
     int find(int x) {
         check(x);
         int root = x;
-        while (parent_[root] != root) root = parent_[root];
-        while (parent_[x] != x) {
+        while (parent_[root] != root) root = parent_[root];  // ① 先找到根
+        while (parent_[x] != x) {           // ② 压缩：沿途节点全部改指根
             int next = parent_[x];
             parent_[x] = root;
             x = next;
@@ -249,36 +262,40 @@ public:
         return root;
     }
 
+    // Union：按大小合并；返回 false 表示两端本来就连通
     bool unite(int a, int b) {
-        a = find(a);
+        a = find(a);                        // ① 先定位两个根（find 顺带完成路径压缩）
         b = find(b);
         if (a == b) return false;
-        if (size_[a] < size_[b]) std::swap(a, b);
-        parent_[b] = a;
-        size_[a] += size_[b];
-        --sets_;
+        if (size_[a] < size_[b]) std::swap(a, b);  // ② 保证 a 是大树根
+        parent_[b] = a;                     // ③ 小根挂大根
+        size_[a] += size_[b];               // ④ 新根大小累加
+        --sets_;                            // ⑤ 有效合并使连通分量数减 1
         return true;
     }
 
-    bool connected(int a, int b) { return find(a) == find(b); }
-    int componentSize(int x) { return size_[find(x)]; }
+    // 便捷查询接口
+    bool connected(int a, int b) { return find(a) == find(b); }  // 同根即连通
+    int componentSize(int x) { return size_[find(x)]; }  // 只有根的 size 有定义，先 find
     int setCount() const { return sets_; }
 
 private:
+    // 防御负数规模：int 直接转 size_t 会变成天文数字，必须先检查
     static std::size_t checkedSize(int n) {
         if (n < 0) throw std::invalid_argument("negative size");
         return static_cast<std::size_t>(n);
     }
 
+    // 防御越界元素编号：越界访问会让 parent_ 读到未定义位置
     void check(int x) const {
         if (x < 0 || x >= static_cast<int>(parent_.size())) {
             throw std::out_of_range("element out of range");
         }
     }
 
-    std::vector<int> parent_;
-    std::vector<int> size_;
-    int sets_;
+    std::vector<int> parent_;   // 父节点数组；parent_[i] == i 表示 i 是根
+    std::vector<int> size_;     // 仅根节点的值有效：该集合的元素个数
+    int sets_;                  // 当前连通分量总数
 };
 ```
 
@@ -294,9 +311,13 @@ $$
 常见简写为每次操作摊还 $O(\alpha(n))$。$\alpha$ 是反阿克曼函数，在现实规模下增长极慢，但这是一组操作序列的**摊还上界**，不是声称每次 `Find` 都严格常数时间，也不是任意朴素实现都自动拥有该界。
 :::
 
-## 5.4.4 实现【C/C++】与应用【拓展】（动态连通性、Kruskal）
+## 5.4.4 应用与拓展
+
+接下来笔者将介绍并查集在图论方面的应用，以及并查集的一些拓展。
 
 ### 增量动态连通性
+
+并查集可以用来快速维护图的连通性，并且同时得到图的连通分量。
 
 无向图开始时没有边，每加入一条边 `(u,v)` 就执行 `unite(u,v)`；询问两点是否连通时执行 `connected(u,v)`。并查集不保存具体路径，只保存连通分量划分，因此比每次从头 DFS/BFS 更适合“只加边、频繁问连通”的场景。
 
@@ -306,56 +327,37 @@ $$
 - 前两次合并后有 `{0,1}`、`{2}`、`{3,4}` 三个分量；
 - 加入 `(1,4)` 后变成 `{0,1,3,4}` 与 `{2}`；
 - `connected(0,3)` 为真，`connected(0,2)` 为假，`setCount()` 为 2。
-:::
+  :::
 
-若需要删除边，删除一条非树边可能不影响连通，删除桥却会拆分集合。普通 DSU 无法逆向拆树；需要离线倒序、可回滚并查集、分治时间线或动态树等更强方法。
-
-### Kruskal 最小生成树
-
-Kruskal 按边权从小到大考虑无向边。若两端已在同一集合，加边会形成环，跳过；否则选中该边并合并分量。
-
-```cpp:line-numbers [kruskal-with-dsu.cpp]
-#include <algorithm>
-#include <stdexcept>
-#include <vector>
-// DisjointSetUnion 见上一节的完整实现
-
-struct Edge { int u; int v; int weight; };
-
-long long kruskal(int vertexCount, std::vector<Edge> edges) {
-    std::sort(edges.begin(), edges.end(),
-              [](const Edge& a, const Edge& b) { return a.weight < b.weight; });
-    DisjointSetUnion dsu(vertexCount);
-    long long total = 0;
-    int chosen = 0;
-    for (const Edge& edge : edges) {
-        if (dsu.unite(edge.u, edge.v)) {
-            total += edge.weight;
-            if (++chosen == vertexCount - 1) break;
-        }
-    }
-    if (vertexCount > 0 && chosen != vertexCount - 1) {
-        throw std::runtime_error("graph is disconnected");
-    }
-    return total;
-}
-```
-
-排序主导复杂度，为 $O(E\log E)$；并查集处理所有边的总成本接近线性。并查集只负责判环和合并，Kruskal 的最优性仍来自最小生成树的切分性质，不能用“DSU 很快”代替正确性证明。
-
-### 能力边界
-
-| 需求 | 普通 DSU 是否适合 | 原因 |
-| --- | --- | --- |
-| 只加边并查询连通 | 适合 | 合并与查询高效 |
-| 返回两点之间的实际路径 | 不适合 | 父数组是代表森林，不是原图路径 |
-| 删除边后保持在线连通查询 | 不直接支持 | 集合可能需要拆分 |
-| 统计每个连通分量大小 | 适合 | 根维护 `size` |
-| 判断有向图强连通分量 | 不适合 | 方向信息被集合划分丢失 |
-
-::: pitfall 易错点 · DSU 父边不是业务图边
+::: pitfall 易错点 · DSU 父边不是原图的边
 路径压缩会把节点直接连到代表根，这条父链接可能根本不是原图中的边。因此不能沿 `parent` 输出网络路径、MST 边或证明距离。
 :::
+
+
+
+### 带删除并查集
+
+作为拓展内容
+
+普通的并查集无法支持删除操作，是因为删除一个节点的时候，不可避免地会将以它为根的子树上所有节点都删除．为了解决这一问题，在带删除操作的并查集中，可以通过建立虚点的方法保证所有实际存储数据的节点总是叶子节点．为此，需要在初始化时，就为每个数据节点都建立一个虚点，并将数据节点的父节点设置为该虚点．由于每次合并两个集合时，都只会将两个集合的树根连接，所以，从始至终只有虚点会有子节点．这就保证了删除一个节点时，不会误删其他节点．
+
+注意，删除单个节点后，需要重新为该节点建立一个虚点作为其父节点；否则，无法正确执行后续的合并和删除操作．
+
+### 带权并查集
+
+我们还可以在并查集的边上定义某种权值和这种权值在路径压缩时产生的运算，从而解决更多的问题．
+
+为了维护并查集中的边权，需要将边权下放到子节点中存储．因此，每个节点存储的都是它到它的父节点之间的边权．只有当一个节点的父节点发生变化时，才需要相应地调整边权．一般情形中，这可能发生在路径压缩和合并两个节点时．例如，如果边权是当前节点与父节点之间的距离，那么，在路径压缩时，每次将当前节点的父节点替换为根节点，都需要将父节点到根节点的距离加到当前节点存储的边权上；类似地，在合并两个节点所在集合时，需要计算两个根节点之间新连接的边的权值．
+
+### 可撤销并查集
+
+笔者先要说明一点，删除操作与撤销操作是不同的。撤销是对操作序列反向进行，比直接删除有着更好的性质。
+
+对于可撤销并查集，我们记录每一步合并的两个DSU树根是什么，撤销的时候直接拆开就行。
+
+需要着重强调的是，这种并查集是不允许路径压缩的 ！！！ 路径压缩会导致无法撤销。只能使用按秩合并的方法优化复杂度 ！！！
+
+
 
 ## 配套 Lab
 

--- a/content/chapter-05-tree-applications/05-b-tree-and-b-plus-tree.md
+++ b/content/chapter-05-tree-applications/05-b-tree-and-b-plus-tree.md
@@ -4,8 +4,8 @@ description: "理解多路平衡搜索树如何减少外存 I/O，并掌握 B �
 order: 5
 chapter: 5
 chapterTitle: "树的应用"
-updated: "2026-08-24"
-contributors: ["Azen"]
+updated: "2026-09-10"
+contributors: ["CzjLUCK&Azen"]
 status: "review"
 ---
 
@@ -107,6 +107,7 @@ digraph BTreeSearchBranch {
 #include <memory>
 #include <vector>
 
+// B 树节点：一个节点对应一个外存页
 struct BTreeNode {
     explicit BTreeNode(bool leaf) : isLeaf(leaf) {}
 
@@ -114,12 +115,15 @@ struct BTreeNode {
     std::vector<int> keys;                              // 至多 2t-1 个，严格递增
     std::vector<std::unique_ptr<BTreeNode>> children;   // 内部节点为 keys.size()+1 个
 
+    // 满节点 = 含 2t-1 个关键字，达到容量上界，必须先分裂才能继续插入
     bool isFull(int t) const {
         return static_cast<int>(keys.size()) == 2 * t - 1;
     }
 };
 
-// 找到第一个不小于 target 的关键字下标；页内可改用二分
+// 页内定位：找到第一个不小于 target 的关键字下标（线性版；页内可改用二分）
+// 返回值 i 满足 keys[i-1] < target <= keys[i]，
+// 因此第 i 个孩子覆盖的区间恰是 keys[i-1] 与 keys[i] 之间的开区间
 int lowerBoundIndex(const BTreeNode& node, int target) {
     int i = 0;
     while (i < static_cast<int>(node.keys.size()) && node.keys[i] < target) {
@@ -128,16 +132,20 @@ int lowerBoundIndex(const BTreeNode& node, int target) {
     return i;
 }
 
+// B 树查找：自根向下逐页定位，每层只读取一个孩子页
 const BTreeNode* search(const BTreeNode* node, int target) {
     while (node != nullptr) {
-        const int i = lowerBoundIndex(*node, target);
+        const int i = lowerBoundIndex(*node, target);   // ① 先在当前页内定位分支
+        // ② 命中：B 树的关键字也“住在”内部节点，可以在这里提前结束
         if (i < static_cast<int>(node->keys.size()) && node->keys[i] == target) {
-            return node;                    // 命中，B 树可在内部节点提前结束
+            return node;
         }
+        // ③ 未命中且已是叶 -> 整棵树都没有 target
         if (node->isLeaf) {
-            return nullptr;                 // 落到叶仍未命中
+            return nullptr;
         }
-        node = node->children[i].get();     // 下降一层，对应一次页读取
+        // ④ 下降到第 i 个孩子页：在外存视角下等价于一次页读取
+        node = node->children[i].get();
     }
     return nullptr;
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "node": ">=22.13.0"
   },
   "scripts": {
-    "dev": "vitepress dev . --host 127.0.0.1",
+    "dev": "vitepress dev .",
     "dev:vitepress": "pnpm run dev",
     "build": "vitepress build .",
     "build:vitepress": "pnpm run build",
-    "preview": "vitepress preview . --host 127.0.0.1",
+    "preview": "vitepress preview .",
     "preview:vitepress": "pnpm run preview",
     "validate": "pnpm run validate:content && pnpm run typecheck && pnpm run lint",
     "validate:content": "node scripts/validate-content.mjs",


### PR DESCRIPTION
## 改动内容
### 0. 手动攥写了部分拓展内容
### 1. 为 02–05 四节共 13 个 C++ 代码块补充详细中文注解
沿用 01 节的注解风格（函数级说明注释 + ①②③ 步骤标注 + 关键行内注释）：

- **02 堆与优先队列**（6 块）：`siftUp`/`push`、`siftDown`/`pop`、`heapify`、堆排序、`std::priority_queue` 用法、Top-K。重点解释无符号下标下溢、必须选较大孩子下沉、`i-- &gt; 0` 写法、堆区/已排序区边界等易错点。
- **03 哈夫曼树**（1 块）：`Lighter` 比较器为何反向写、合并循环不变量、单符号编码特判为 `"0"` 的原因。
- **04 并查集**（5 块）：基础 find/unite、递归路径压缩、按大小合并、完整实现类（两遍迭代压缩、`checkedSize`/`check` 防御、`--sets_` 维护分量数）。
- **05 B 树**（1 块）：节点即外存页、`lowerBoundIndex` 与孩子区间的对应关系、`search` 四步流程（页内定位 → 内部节点可提前命中 → 叶未命中 → 下降 = 一次页 I/O）。

### 2. 修复 01 页导致的构建错误（重要）
`01-binary-search-tree-and-avl.md` 中存在两个 `&lt;script setup&gt;` 块，Vue SFC 只允许一个，导致 `vitepress build` **直接失败**。已合并为单个脚本块（同时定义 `bstDemoUrl` / `avlDemoUrl`），BST 与 AVL 两个交互演示的 iframe 分别引用。

### 3. package.json dev/preview 脚本
去掉硬编码的 `--host 127.0.0.1`，使外部传入的 host/port 参数能干净地透传给 vitepress（不影响原有行为）。

## 验证
- `vitepress build` 全站构建通过（此前因第 2 点失败）。
- 构建产物中逐项确认 02–05 各页注解渲染、01 页两个 demo 引用与 `public/demos/` 下文件均正常。
- 四个文件围栏配对无误，行尾统一为 CRLF。

署名：czjLUCK